### PR TITLE
docs: update local build instructions with lib/kof.jar workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ kof version
 
 ```bash
 mvn clean package -DskipTests
+mkdir -p lib
+cp kof-cli/target/kof-cli-*.jar lib/kof.jar
 bin/kof info
 ```
 


### PR DESCRIPTION
Descrição da Melhoria:
Adição dos comandos mkdir -p lib e cp na seção de build local.

Motivo:
Ao rodar apenas o mvn clean package e tentar executar o bin/kof info em seguida, o terminal retorna o erro distribution incomplete — missing lib/kof.jar (pois o binário fica na pasta target do kof-cli). Esses comandos adicionais automatizam o workaround para quem está baixando e compilando a linguagem localmente para testar.

Ambiente testado: Lubuntu, Java 21, Maven 3.6.3.
[kof-init.bmp](https://github.com/user-attachments/files/31353167/kof-init.bmp)

