### PR TITLE
fix: CI multiplataforma + kof.db link seletivo + JS try/finally + pac…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           - os: windows-latest
             target: windows-x86_64
           - os: macos-latest
-            target: macos-x86_64
+            target: macos-arm64
     steps:
       - name: Checkout (bumped main)
         uses: actions/checkout@v4
@@ -113,7 +113,12 @@ jobs:
         shell: bash
         run: |
           VERSION=$(cat VERSION)
-          ARCHIVE=$(ls dist/kof-${VERSION}-*.tar.gz dist/kof-${VERSION}-*.zip 2>/dev/null | head -1)
+          ARCHIVE=$(ls dist/kof-${VERSION}-*.tar.gz dist/kof-${VERSION}-*.zip 2>/dev/null | head -1 || true)
+          if [ -z "$ARCHIVE" ]; then
+            echo "no archive found in dist/ for kof-${VERSION}" >&2
+            ls -la dist/ >&2 || true
+            exit 1
+          fi
           echo "validating $ARCHIVE"
           rm -rf /tmp/kof-validate && mkdir -p /tmp/kof-validate
           if [[ "$ARCHIVE" == *.zip ]]; then

--- a/README.md
+++ b/README.md
@@ -344,14 +344,40 @@ kof version
 
 ---
 
-# Construindo
+---
+
+# Compilando e instalando a partir do source
+
+**Requisitos:** JDK 21+ (Temurin recomendado — é a Tooling API baseline) e
+Maven 3.9+. Para o target `native`: `as`/`ld` (binutils). O target `js` não
+exige nada externo (GraalJS embarcado no jar).
 
 ```bash
+# 1. Compilar tudo (compilador, runtime, CLI com GraalJS embarcado)
 mvn clean package -DskipTests
+
+# 2. Rodar a suíte completa (JVM + Native + KofJS E2E)
+mvn test
+
+# 3. Usar direto do source (dev build, java do sistema)
 mkdir -p lib
-cp kof-cli/target/kof-cli-*.jar lib/kof.jar
+cp kof-cli/target/kof-cli-$(cat VERSION).jar lib/kof.jar
+bin/kof version
 bin/kof info
+
+# 4. Instalar num prefixo (instalação local completa)
+bin/kof install ~/.kof
+export PATH="$HOME/.kof/bin:$PATH"
+kof version
+
+# 5. Empacotar a distribuição oficial (com OpenJDK 21 embutido)
+scripts/package.sh --jdk      # gera dist/kof-<versão>-<os>-<arch>.tar.gz
 ```
+
+O `kof install <dir>` copia o `kof.jar` para `<dir>/lib/` e gera o launcher
+`<dir>/bin/kof` (usa o JDK embutido de `<dir>/jdk/` quando presente; senão o
+`java` do sistema). O `scripts/package.sh --jdk` baixa o Temurin 21 do
+Adoptium e monta o layout completo de distribuição.
 
 Versionamento centralizado em `VERSION` — ver
 [docs/distribution/VERSIONING.md](docs/distribution/VERSIONING.md).

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -48,6 +48,14 @@ case "$ARCH" in
     aarch64|arm64) ARCH=arm64 ;;
 esac
 
+# Adoptium Tooling API usa x64 e aarch64 (não x86_64/arm64) — mapear
+# para o download do JDK embarcado sem mudar o nome do target.
+JDK_ARCH="$ARCH"
+case "$JDK_ARCH" in
+    x86_64) JDK_ARCH=x64 ;;
+    arm64)  JDK_ARCH=aarch64 ;;
+esac
+
 TARGET="$OS-$ARCH"
 DIST_NAME="kof-$VERSION-$TARGET"
 DIST_DIR="$OUT/$DIST_NAME"
@@ -94,7 +102,7 @@ if [ "$WITH_JDK" = true ]; then
         *) echo "package: no JDK mapping for $OS — skipping embedded JDK" >&2 ;;
     esac
     if [ -n "${JDK_OS:-}" ]; then
-        URL="https://api.adoptium.net/v3/binary/latest/21/ga/$JDK_OS/$ARCH/jdk/hotspot/normal/eclipse"
+        URL="https://api.adoptium.net/v3/binary/latest/21/ga/$JDK_OS/$JDK_ARCH/jdk/hotspot/normal/eclipse"
         TMP_JDK="$OUT/.jdk-download.$JDK_EXT"
         curl -fL --retry 3 -o "$TMP_JDK" "$URL"
         mkdir -p "$DIST_DIR/jdk"


### PR DESCRIPTION
…kage Adoptium

- IoE2ETest (e todos os E2E): stdout capturado normaliza CRLF e usa UTF-8 — corrige o build do Windows (separadores de path e unicode)
- JvmRuntime: paths de kof.io retornam o separador canônico '/' em qualquer OS (entrada aceita '\'); kof_io_* multiplataforma
- NativeRuntime: remove linha corrompida ('movb leaq ...') no secret_get nativo (quebrava o asm do kof.security)
- NativeBackend: kof.db linka libmariadb apenas quando o programa usa MySQL (URL literal detectado em compile-time) — SQLite nativo não exige libs ausentes no CI (G7/G10 da auditoria)
- JsBackend: KofTryEnd encerra o parseStatements da região (try dentro de loop com catch → o jump para o continueLabel não consumia o fim do try); label de loop não é tratado como finally — corrige o bench stress/exceptions no target js
- package.sh: Adoptium usa x64/aarch64 (não x86_64/arm64) — corrige o 404 do download do JDK embarcado em todas as plataformas
- release.yml: matrix macos-arm64 (runner ARM64) e validate robusto com mensagem clara quando o archive falta
- README: seção de compilação e instalação a partir do source