### PR TITLE
fix(release): Windows — o zip do JDK não preserva o bit de execução; …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
           DIR=$(ls -d /tmp/kof-validate/*/)
           "$DIR/bin/kof" version
           "$DIR/bin/kof" info
-          test -x "$DIR/jdk/bin/java" || test -x "$DIR/jdk/bin/java.exe" \
+          test -x "$DIR/jdk/bin/java" || test -f "$DIR/jdk/bin/java.exe" \
             && echo "embedded JDK present"
 
       - name: Upload artifact

--- a/bin/kof
+++ b/bin/kof
@@ -30,7 +30,8 @@ JAVA="$(command -v java || true)"
 if [ -x "$KOF_HOME/jdk/bin/java" ]; then
     JAVA="$KOF_HOME/jdk/bin/java"
     EMBEDDED=true
-elif [ -x "$KOF_HOME/jdk/bin/java.exe" ]; then
+elif [ -f "$KOF_HOME/jdk/bin/java.exe" ]; then
+    # no Windows o zip não preserva o bit de execução unix — basta existir
     JAVA="$KOF_HOME/jdk/bin/java.exe"
     EMBEDDED=true
 elif [ -x "$KOF_HOME/jdk/Contents/Home/bin/java" ]; then


### PR DESCRIPTION
…aceitar java.exe por existência (-f) no launcher e no validate