### PR TITLE
feat(web): JVM native SSE + trailing-block sugar

### DIFF
--- a/kof-compiler/src/main/java/dev/kof/compiler/CompilerDriver.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/CompilerDriver.java
@@ -3458,7 +3458,7 @@ private Target target = Target.JVM;
                 } else if (mc.receiver() instanceof IdentifierExpr rid && !isLocalVarName(rid.name(), locals)
                             && KofWeb.isWebNamespace(rid.name())) {
                     if ("app".equals(mc.methodName()) && mc.arguments().isEmpty()) {
-                        if (target != Target.JVM) {
+                        if (target != Target.JVM && target != Target.ANDROID) {
                             if (currentDiagnostics != null) {
                                 currentDiagnostics.error(mc.position() != null ? mc.position().file() : "",
                                         mc.position() != null ? mc.position().line() : 0,
@@ -3624,11 +3624,18 @@ private Target target = Target.JVM;
                         for (ExpressionNode arg : mc.arguments()) webArgTypes.add(inferExprType(arg, locals));
                         KofWeb.WebCall webCall = KofWeb.instanceMethod(mc.methodName(), webArgTypes);
                         if (webCall != null) {
-                            if (target != Target.JVM) {
-                                String webCode = "kof_web_listen_secure".equals(webCall.function()) ? "WEB002" : "WEB001";
-                                String webMsg = "kof_web_listen_secure".equals(webCall.function())
-                                        ? "web TLS: not available on the " + target + " target yet (WEB002)"
-                                        : "web: not available on the " + target + " target yet (WEB001)";
+                            if (target != Target.JVM && target != Target.ANDROID) {
+                                String webCode = KofWeb.gapCode(webCall.function());
+                                String webMsg = switch (webCode) {
+                                    case "WEB002" -> "web TLS: not available on the " + target
+                                            + " target yet (WEB002)";
+                                    case "WEB003" -> "web SSE: not available on the " + target
+                                            + " target yet (WEB003)";
+                                    case "WEB004" -> "web WebSocket: not available on the " + target
+                                            + " target yet (WEB004)";
+                                    default -> "web: not available on the " + target
+                                            + " target yet (WEB001)";
+                                };
                                 if (currentDiagnostics != null) {
                                     currentDiagnostics.error(mc.position() != null ? mc.position().file() : "",
                                             mc.position() != null ? mc.position().line() : 0,
@@ -3637,18 +3644,16 @@ private Target target = Target.JVM;
                                 }
                                 yield localIdx;
                             }
-                            if (KofWeb.isRouteMethod(mc.methodName())) {
-                                ops.add(new KofLoadLiteral(BuiltinTypes.STRING, mc.methodName().toUpperCase()));
-                            }
-                            for (ExpressionNode arg : mc.arguments()) {
-                                localIdx = emitExpression(arg, ops, owner, localIdx, locals);
-                            }
                             List<Type> webParams = new ArrayList<>();
                             webParams.add(BuiltinTypes.STRING);
-                            if (KofWeb.isRouteMethod(mc.methodName())) {
+                            if (KofWeb.isRouteMethod(mc.methodName()) && !"ws".equals(mc.methodName())) {
+                                ops.add(new KofLoadLiteral(BuiltinTypes.STRING, mc.methodName().toUpperCase()));
                                 webParams.add(BuiltinTypes.STRING);
                             }
-                            webParams.addAll(webCall.parameterTypes());
+                            for (ExpressionNode arg : mc.arguments()) {
+                                webParams.add(inferExprType(arg, locals));
+                                localIdx = emitExpression(arg, ops, owner, localIdx, locals);
+                            }
                             ops.add(new KofCall(KofWeb.APP, webCall.function(), webParams,
                                     webCall.returnType(), KofCallKind.FUNCTION));
                         }

--- a/kof-compiler/src/main/java/dev/kof/compiler/JvmRuntime.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/JvmRuntime.java
@@ -153,6 +153,8 @@ static boolean hasRuntimeFn(String methodName) {
             case "kof_io_dir_list" -> "(Ljava/lang/String;)Ljava/util/ArrayList;";
             case "kof_web_app_new" -> "()Ljava/lang/String;";
             case "kof_web_route" -> "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V";
+            case "kof_web_sse_route" -> "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V";
+            case "kof_web_ws_route" -> "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V";
             case "kof_web_use" -> "(Ljava/lang/String;Ljava/lang/Object;)V";
             case "kof_web_listen" -> "(Ljava/lang/String;I)V";
             case "kof_web_listen_secure" -> "(Ljava/lang/String;I)V";
@@ -326,7 +328,8 @@ static boolean hasRuntimeFn(String methodName) {
             case "kof_http_status", "kof_mq_queue_size" -> "I";
             case "kof_mq_queue" -> "Ljava/lang/String;";
             case "kof_mq_pop" -> "Ljava/lang/Object;";
-            case "kof_http_timeout_set", "kof_mq_publish", "kof_mq_subscribe", "kof_mq_unsubscribe",
+            case "kof_web_sse_route", "kof_web_ws_route", "kof_http_timeout_set",
+                    "kof_mq_publish", "kof_mq_subscribe", "kof_mq_unsubscribe",
                     "kof_mq_push", "kof_time_sleep", "kof_time_cancel", "kof_scheduler_cancel" -> "V";
             case "kof_time_now" -> "J";
             case "kof_time_interval" -> "Ljava/lang/String;";
@@ -420,6 +423,9 @@ static boolean hasRuntimeFn(String methodName) {
                     while (app.running) {
                         try {
                             java.net.Socket client = app.serverSocket.accept();
+                            // 15s default protects HTTP `readRequest` against
+                            // client half-open sockets. SSE/WS override this
+                            // higher inside `kof_web_keep_alive`.
                             client.setSoTimeout(15000);
                             Thread.startVirtualThread(() -> kof_web_handle(app, client));
                         } catch (java.io.IOException e) {
@@ -483,15 +489,39 @@ static boolean hasRuntimeFn(String methodName) {
                 private static void kof_web_handle(WebApp app, java.net.Socket client) {
                     try (client) {
                         WebRequest req = readRequest(client.getInputStream());
-                        String response = kof_web_dispatch(app, req);
-                        client.getOutputStream().write(response.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                        WebDispatchResult result = kof_web_dispatch(app, req);
+                        if (result.kind != RouteKind.HTTP) {
+                            kof_web_keep_alive(client);
+                            return;
+                        }
+                        client.getOutputStream().write(result.response.getBytes(java.nio.charset.StandardCharsets.UTF_8));
                         client.getOutputStream().flush();
                     } catch (Exception e) {
                         System.err.println("kof web connection error: " + e.getMessage());
                     }
                 }
 
-                private static String kof_web_dispatch(WebApp app, WebRequest req) {
+                // Idle timeout for persistent connections (SSE/WS in PR2/PR3).
+                // Without this, a client that opens the socket and never sends
+                // data would pin a virtual thread indefinitely. PR6 may move
+                // this to a configurable `web.configure(...)` knob.
+                private static final int KEEPALIVE_IDLE_MS = 300_000;
+
+                private static void kof_web_keep_alive(java.net.Socket client) throws java.io.IOException {
+                    client.setSoTimeout(KEEPALIVE_IDLE_MS);
+                    byte[] buffer = new byte[8192];
+                    try {
+                        while (client.getInputStream().read(buffer) != -1) {
+                            // PR1: no SSE/WS protocol yet; PR2/PR3 replace this with real loops.
+                            // Until then, any bytes from the client are discarded.
+                        }
+                    } catch (java.net.SocketTimeoutException idle) {
+                        // Idle socket — close cleanly. PR2 will replace this body with
+                        // real SSE/WS loops that respect the same per-read budget.
+                    }
+                }
+
+                private static WebDispatchResult kof_web_dispatch(WebApp app, WebRequest req) {
                     KOF_WEB_REQUEST.set(req);
                     KOF_WEB_STATUS.remove();
                     KOF_WEB_HEADERS.get().clear();
@@ -506,11 +536,11 @@ static boolean hasRuntimeFn(String methodName) {
                                 String resp = kof_web_build(code, text, String.valueOf(result));
                                 KOF_WEB_STATUS.remove();
                                 KOF_WEB_HEADERS.get().clear();
-                                return resp;
+                                return new WebDispatchResult(RouteKind.HTTP, resp);
                             }
                         }
                         for (WebRoute route : app.routes) {
-                            if (!route.method.equals(req.method)) continue;
+                            if (route.kind == RouteKind.HTTP && !route.method.equals(req.method)) continue;
                             String[] pathSegs = req.path.split("/");
                             if (pathSegs.length != route.segments.length) continue;
                             boolean match = true;
@@ -525,13 +555,19 @@ static boolean hasRuntimeFn(String methodName) {
                             }
                             if (!match) continue;
                             req.params.putAll(params);
+                            if (route.kind != RouteKind.HTTP) {
+                                KOF_WEB_STATUS.remove();
+                                KOF_WEB_HEADERS.get().clear();
+                                return new WebDispatchResult(route.kind, null);
+                            }
                             KOF_WEB_STATUS.remove();
                             KOF_WEB_HEADERS.get().clear();
                             Object result = kof_web_invoke(route.handler, req);
                             if (result == null) {
                                 KOF_WEB_STATUS.remove();
                                 KOF_WEB_HEADERS.get().clear();
-                                return kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}");
+                                return new WebDispatchResult(RouteKind.HTTP,
+                                        kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}"));
                             }
                             Integer st2 = KOF_WEB_STATUS.get();
                             int code2 = st2 != null ? st2 : 200;
@@ -539,15 +575,17 @@ static boolean hasRuntimeFn(String methodName) {
                             String resp2 = kof_web_build(code2, text2, String.valueOf(result));
                             KOF_WEB_STATUS.remove();
                             KOF_WEB_HEADERS.get().clear();
-                            return resp2;
+                            return new WebDispatchResult(RouteKind.HTTP, resp2);
                         }
-                        return kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}");
+                        return new WebDispatchResult(RouteKind.HTTP,
+                                kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}"));
                     } catch (Exception e) {
                         String msg = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
                         KOF_WEB_STATUS.remove();
                         KOF_WEB_HEADERS.get().clear();
-                        return kof_web_build(500, "Internal Server Error",
-                                "{\\"error\\": \\"handler error: " + msg + "\\"}");
+                        return new WebDispatchResult(RouteKind.HTTP,
+                                kof_web_build(500, "Internal Server Error",
+                                        "{\\"error\\": \\"handler error: " + msg + "\\"}"));
                     } finally {
                         KOF_WEB_REQUEST.remove();
                         KOF_LOG_REQUEST_ID.remove();

--- a/kof-compiler/src/main/java/dev/kof/compiler/JvmRuntime.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/JvmRuntime.java
@@ -490,6 +490,34 @@ static boolean hasRuntimeFn(String methodName) {
                     try (client) {
                         WebRequest req = readRequest(client.getInputStream());
                         WebDispatchResult result = kof_web_dispatch(app, req);
+                        if (result.kind == RouteKind.SSE) {
+                            java.io.OutputStream out = client.getOutputStream();
+                            out.write(("HTTP/1.1 200 OK\\r\\n"
+                                    + "Content-Type: text/event-stream\\r\\n"
+                                    + "Cache-Control: no-cache\\r\\n"
+                                    + "Connection: keep-alive\\r\\n"
+                                    + "X-Accel-Buffering: no\\r\\n"
+                                    + "\\r\\n").getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                            out.flush();
+                            SseConnection sse = new SseConnection(out);
+                            Thread handler = Thread.startVirtualThread(() -> {
+                                try {
+                                    KOF_WEB_REQUEST.set(req);
+                                    try {
+                                        kof_web_invoke(result.route.handler, sse);
+                                    } finally {
+                                        KOF_WEB_REQUEST.remove();
+                                    }
+                                } catch (Exception e) {
+                                    System.err.println("kof web sse handler error: "
+                                            + e.getMessage());
+                                } finally {
+                                    sse.close();
+                                }
+                            });
+                            handler.join();
+                            return;
+                        }
                         if (result.kind != RouteKind.HTTP) {
                             kof_web_keep_alive(client);
                             return;
@@ -536,7 +564,7 @@ static boolean hasRuntimeFn(String methodName) {
                                 String resp = kof_web_build(code, text, String.valueOf(result));
                                 KOF_WEB_STATUS.remove();
                                 KOF_WEB_HEADERS.get().clear();
-                                return new WebDispatchResult(RouteKind.HTTP, resp);
+                                return new WebDispatchResult(RouteKind.HTTP, resp, null);
                             }
                         }
                         for (WebRoute route : app.routes) {
@@ -558,7 +586,7 @@ static boolean hasRuntimeFn(String methodName) {
                             if (route.kind != RouteKind.HTTP) {
                                 KOF_WEB_STATUS.remove();
                                 KOF_WEB_HEADERS.get().clear();
-                                return new WebDispatchResult(route.kind, null);
+                                return new WebDispatchResult(route.kind, null, route);
                             }
                             KOF_WEB_STATUS.remove();
                             KOF_WEB_HEADERS.get().clear();
@@ -567,7 +595,7 @@ static boolean hasRuntimeFn(String methodName) {
                                 KOF_WEB_STATUS.remove();
                                 KOF_WEB_HEADERS.get().clear();
                                 return new WebDispatchResult(RouteKind.HTTP,
-                                        kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}"));
+                                        kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}"), null);
                             }
                             Integer st2 = KOF_WEB_STATUS.get();
                             int code2 = st2 != null ? st2 : 200;
@@ -575,17 +603,17 @@ static boolean hasRuntimeFn(String methodName) {
                             String resp2 = kof_web_build(code2, text2, String.valueOf(result));
                             KOF_WEB_STATUS.remove();
                             KOF_WEB_HEADERS.get().clear();
-                            return new WebDispatchResult(RouteKind.HTTP, resp2);
+                            return new WebDispatchResult(RouteKind.HTTP, resp2, null);
                         }
                         return new WebDispatchResult(RouteKind.HTTP,
-                                kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}"));
+                                kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}"), null);
                     } catch (Exception e) {
                         String msg = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
                         KOF_WEB_STATUS.remove();
                         KOF_WEB_HEADERS.get().clear();
                         return new WebDispatchResult(RouteKind.HTTP,
                                 kof_web_build(500, "Internal Server Error",
-                                        "{\\"error\\": \\"handler error: " + msg + "\\"}"));
+                                        "{\\"error\\": \\"handler error: " + msg + "\\"}"), null);
                     } finally {
                         KOF_WEB_REQUEST.remove();
                         KOF_LOG_REQUEST_ID.remove();
@@ -603,6 +631,11 @@ static boolean hasRuntimeFn(String methodName) {
                                         String.class, String.class)
                                 .invoke(target, req.method, req.path, req.body, req.query, req.rawHeaders);
                     }
+                }
+
+                private static Object kof_web_invoke(Object target, SseConnection sse) throws Exception {
+                    return target.getClass().getMethod("invoke", SseConnection.class)
+                            .invoke(target, sse);
                 }
 
                 private static String kof_web_build(int status, String statusText, String body) {

--- a/kof-compiler/src/main/java/dev/kof/compiler/JvmWebRuntime.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/JvmWebRuntime.java
@@ -58,7 +58,7 @@ final class JvmWebRuntime {
 
                 public enum RouteKind { HTTP, SSE, WS }
 
-                record WebDispatchResult(RouteKind kind, String response) {}
+                record WebDispatchResult(RouteKind kind, String response, WebRoute route) {}
 
                 public static final class WebRoute {
                     final String method;
@@ -124,6 +124,65 @@ final class JvmWebRuntime {
 
                     String header(String name) {
                         return headers.get(name.toLowerCase());
+                    }
+                }
+
+                public static final class SseConnection {
+                    private final java.io.OutputStream out;
+                    private final byte[] nl = "\\n".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                    private final java.util.concurrent.atomic.AtomicBoolean open =
+                            new java.util.concurrent.atomic.AtomicBoolean(true);
+                    private final java.util.concurrent.locks.ReentrantLock writeLock =
+                            new java.util.concurrent.locks.ReentrantLock();
+
+                    SseConnection(java.io.OutputStream out) {
+                        this.out = out;
+                    }
+
+                    public void send(String data) {
+                        writeData(data);
+                    }
+
+                    public void event(String name, String data) {
+                        writeFrame("event: " + name + "\\n");
+                        writeData(data);
+                    }
+
+                    public void close() {
+                        if (open.compareAndSet(true, false)) {
+                            writeLock.lock();
+                            try {
+                                out.flush();
+                                out.close();
+                            } catch (java.io.IOException ignored) {
+                            } finally {
+                                writeLock.unlock();
+                            }
+                        }
+                    }
+
+                    public boolean isOpen() {
+                        return open.get();
+                    }
+
+                    private void writeData(String data) {
+                        for (String line : data.split("\\n", -1)) {
+                            writeFrame("data: " + line + "\\n");
+                        }
+                        writeFrame("\\n");
+                    }
+
+                    private void writeFrame(String frame) {
+                        if (!open.get()) return;
+                        writeLock.lock();
+                        try {
+                            out.write(frame.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                            out.flush();
+                        } catch (java.io.IOException e) {
+                            open.set(false);
+                        } finally {
+                            writeLock.unlock();
+                        }
                     }
                 }
 

--- a/kof-compiler/src/main/java/dev/kof/compiler/JvmWebRuntime.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/JvmWebRuntime.java
@@ -56,13 +56,19 @@ final class JvmWebRuntime {
                     };
                 }
 
+                public enum RouteKind { HTTP, SSE, WS }
+
+                record WebDispatchResult(RouteKind kind, String response) {}
+
                 public static final class WebRoute {
                     final String method;
                     final String[] segments;
                     final boolean[] params;
                     final Object handler;
+                    final RouteKind kind;
 
-                    WebRoute(String method, String path, Object handler) {
+                    WebRoute(RouteKind kind, String method, String path, Object handler) {
+                        this.kind = kind;
                         this.method = method;
                         String[] raw = path.split("/");
                         this.segments = new String[raw.length];
@@ -148,9 +154,23 @@ final class JvmWebRuntime {
                 public static void kof_web_route(String appId, String method, String path, Object handler) {
                     if (handler == null) throw new IllegalArgumentException("route handler is null");
                     String m = method.toUpperCase();
-                    if ("WS".equals(m)) m = "GET";
-                    if ("SSE".equals(m)) m = "GET";
-                    kof_web_app(appId).routes.add(new WebRoute(m, path, handler));
+                    if ("SSE".equals(m) || "WS".equals(m)) {
+                        throw new IllegalArgumentException(
+                                "route method " + m + " requires kof_web_sse_route/kof_web_ws_route");
+                    }
+                    kof_web_app(appId).routes.add(new WebRoute(RouteKind.HTTP, m, path, handler));
+                }
+
+                public static void kof_web_sse_route(String appId, String method, String path, Object handler) {
+                    if (handler == null) throw new IllegalArgumentException("route handler is null");
+                    kof_web_app(appId).routes.add(
+                            new WebRoute(RouteKind.SSE, method.toUpperCase(), path, handler));
+                }
+
+                public static void kof_web_ws_route(String appId, String path, Object handler) {
+                    if (handler == null) throw new IllegalArgumentException("route handler is null");
+                    kof_web_app(appId).routes.add(
+                            new WebRoute(RouteKind.WS, "WS", path, handler));
                 }
 
                 public static void kof_web_use(String appId, Object handler) {

--- a/kof-compiler/src/main/java/dev/kof/compiler/KofWeb.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/KofWeb.java
@@ -25,6 +25,8 @@ final class KofWeb {
     private KofWeb() {}
 
     static final Type APP = new Type.ClassType("kof.web", "App", List.of());
+    static final Type SSE_CONNECTION =
+            new Type.ClassType("dev.kof.runtime", "KofRuntime$SseConnection", List.of());
 
     private static final Type STR = BuiltinTypes.STRING;
     private static final Type INT = Type.PrimitiveType.INT;
@@ -36,6 +38,25 @@ final class KofWeb {
 
     static boolean isAppType(Type t) {
         return APP.equals(t);
+    }
+
+    static boolean isSseConnectionType(Type t) {
+        return SSE_CONNECTION.equals(t);
+    }
+
+    /** Methods available on the synthetic {@code sse} handler parameter. */
+    static WebCall sseConnectionMethod(String name, List<Type> argTypes) {
+        return switch (name) {
+            case "send" -> argTypes.size() == 1
+                    ? new WebCall(name, VOID, argTypes) : null;
+            case "event" -> argTypes.size() == 2
+                    ? new WebCall(name, VOID, argTypes) : null;
+            case "close" -> argTypes.isEmpty()
+                    ? new WebCall(name, VOID, List.of()) : null;
+            case "isOpen" -> argTypes.isEmpty()
+                    ? new WebCall(name, Type.PrimitiveType.BOOL, List.of()) : null;
+            default -> null;
+        };
     }
 
     static boolean isWebNamespace(String name) {

--- a/kof-compiler/src/main/java/dev/kof/compiler/KofWeb.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/KofWeb.java
@@ -68,6 +68,12 @@ final class KofWeb {
     /** Instance methods on {@code kof.web.App} receivers. */
     static WebCall instanceMethod(String name, List<Type> argTypes) {
         if (ROUTE_METHODS.contains(name)) {
+            if ("sse".equals(name)) {
+                return instanceSseMethod(name, argTypes);
+            }
+            if ("ws".equals(name)) {
+                return instanceWsMethod(name, argTypes);
+            }
             if (argTypes.size() == 2) {
                 return new WebCall("kof_web_route", VOID,
                         List.of(STR, STR, STR, argTypes.get(1)));
@@ -91,6 +97,34 @@ final class KofWeb {
                     ? new WebCall("kof_web_close", VOID, List.of(STR))
                     : null;
             default -> null;
+        };
+    }
+
+
+    /** {@code app.sse(path, handler)} — route kind SSE, protocol comes later. */
+    static WebCall instanceSseMethod(String name, List<Type> argTypes) {
+        return "sse".equals(name) && argTypes.size() == 2
+                ? new WebCall("kof_web_sse_route", VOID,
+                        List.of(STR, STR, STR, argTypes.get(1)))
+                : null;
+    }
+
+
+    /** {@code app.ws(path, handler)} — route kind WS, protocol comes later. */
+    static WebCall instanceWsMethod(String name, List<Type> argTypes) {
+        return "ws".equals(name) && argTypes.size() == 2
+                ? new WebCall("kof_web_ws_route", VOID,
+                        List.of(STR, STR, argTypes.get(1)))
+                : null;
+    }
+
+
+    static String gapCode(String function) {
+        return switch (function) {
+            case "kof_web_sse_route" -> "WEB003";
+            case "kof_web_ws_route" -> "WEB004";
+            case "kof_web_listen_secure" -> "WEB002";
+            default -> "WEB001";
         };
     }
 

--- a/kof-compiler/src/main/java/dev/kof/compiler/SemanticAnalyzer.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/SemanticAnalyzer.java
@@ -8,6 +8,9 @@ import java.util.Map;
 
 class SemanticAnalyzer {
 
+    private static final String SSE_CONNECTION_TYPE =
+            "dev.kof.runtime.KofRuntime$SseConnection";
+
     private SymbolTable currentScope;
     private CompilationUnitNode currentUnit;
 
@@ -1193,10 +1196,24 @@ class SemanticAnalyzer {
                         yield KofWeb.APP;
                     }
                     if (KofWeb.isAppType(recvType)) {
+                        if ("sse".equals(mc.methodName()) && mc.arguments().size() == 2
+                                && mc.arguments().get(1) instanceof LambdaExpr le
+                                && le.parameters().isEmpty()) {
+                            mc.arguments().set(1, new LambdaExpr(le.position(),
+                                    List.of(new FormalParameterNode(le.position(), List.of(),
+                                            SSE_CONNECTION_TYPE, "sse")), le.body()));
+                        }
                         List<Type> argTypes = new ArrayList<>();
                         for (ExpressionNode arg : mc.arguments()) argTypes.add(inferType(arg, scope));
                         KofWeb.WebCall webCall = KofWeb.instanceMethod(mc.methodName(), argTypes);
                         if (webCall != null) yield webCall.returnType();
+                        yield Type.UnknownType.UNKNOWN;
+                    }
+                    if (KofWeb.isSseConnectionType(recvType)) {
+                        List<Type> argTypes = new ArrayList<>();
+                        for (ExpressionNode arg : mc.arguments()) argTypes.add(inferType(arg, scope));
+                        KofWeb.WebCall sseCall = KofWeb.sseConnectionMethod(mc.methodName(), argTypes);
+                        if (sseCall != null) yield sseCall.returnType();
                         yield Type.UnknownType.UNKNOWN;
                     }
                     if (recvType instanceof Type.FunctionType ft) {

--- a/kof-compiler/src/test/java/dev/kof/compiler/KofWebE2ETest.java
+++ b/kof-compiler/src/test/java/dev/kof/compiler/KofWebE2ETest.java
@@ -221,4 +221,22 @@ class KofWebE2ETest {
         assertEquals("A", bodyOf(request(port, "GET /a HTTP/1.1\r\nHost: x\r\n\r\n")));
         assertEquals("B", bodyOf(request(port, "GET /b HTTP/1.1\r\nHost: x\r\n\r\n")));
     }
+
+    @Test
+    void sseAndWsGapOnNative(@TempDir Path tempDir) throws IOException {
+        Path source = tempDir.resolve("App.kf");
+        Files.writeString(source, """
+                main() {
+                    var app = web.app()
+                    app.sse("/events") { return "x" }
+                    app.ws("/chat") { return "x" }
+                }
+                """);
+        CompilationResult result = driver.compile(source, tempDir.resolve("out"), Target.NATIVE);
+        var diagnostics = result.diagnostics().getDiagnostics();
+        assertTrue(diagnostics.stream().anyMatch(d -> d.code().equals("WEB003")),
+                "Should have WEB003, got: " + diagnostics);
+        assertTrue(diagnostics.stream().anyMatch(d -> d.code().equals("WEB004")),
+                "Should have WEB004, got: " + diagnostics);
+    }
 }

--- a/kof-compiler/src/test/java/dev/kof/compiler/KofWebSseE2ETest.java
+++ b/kof-compiler/src/test/java/dev/kof/compiler/KofWebSseE2ETest.java
@@ -1,0 +1,290 @@
+package dev.kof.compiler;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * E2E tests for the Kof-native SSE stack ({@code app.sse(...)}).
+ */
+class KofWebSseE2ETest {
+
+    private static final String JAVA_BIN = Path.of(
+            System.getProperty("java.home"), "bin", "java").toString();
+
+    private Process serverProcess;
+
+    @AfterEach
+    void stopServer() {
+        if (serverProcess != null) {
+            serverProcess.destroy();
+            try {
+                serverProcess.waitFor(5, TimeUnit.SECONDS);
+            } catch (InterruptedException ignored) {
+            }
+            serverProcess.destroyForcibly();
+            serverProcess = null;
+        }
+    }
+
+    private static final String SSE_APP = """
+            main() {
+                var app = web.app()
+                app.sse("/events") {
+                    HANDLER
+                }
+                app.listen(PORT)
+            }
+            """;
+
+    private static Path testClassesDir() throws Exception {
+        return Path.of(KofWebSseE2ETest.class.getProtectionDomain()
+                .getCodeSource().getLocation().toURI()).toRealPath();
+    }
+
+    private int startSseServer(Path tempDir, String handlerBody) throws Exception {
+        return startServer(tempDir, SSE_APP.replace("HANDLER", handlerBody));
+    }
+
+    private int startServer(Path tempDir, String kofSource) throws Exception {
+        int port = freePort();
+        Path sourceFile = tempDir.resolve("App.kf");
+        Files.writeString(sourceFile, kofSource.replace("PORT", String.valueOf(port)));
+        Path outDir = tempDir.resolve("classes");
+        CompilerDriver driver = new CompilerDriver();
+        driver.setExternalClasspath(List.of(testClassesDir()));
+        CompilationResult result = driver.compile(sourceFile, outDir, Target.JVM);
+        assertTrue(result.success(), "Compilation should succeed: "
+                + result.diagnostics().getDiagnostics());
+        ProcessBuilder pb = new ProcessBuilder(JAVA_BIN, "-cp", outDir.toString(), "Default.Main");
+        pb.redirectErrorStream(true);
+        serverProcess = pb.start();
+        int attempt = 0;
+        while (attempt < 40) {
+            if (!serverProcess.isAlive()) {
+                String out = new String(serverProcess.getInputStream().readAllBytes(),
+                                StandardCharsets.UTF_8)
+                        .replace("\r\n", "\n").trim();
+                throw new IOException("server exited early: " + out);
+            }
+            try (Socket probe = new Socket()) {
+                probe.connect(new java.net.InetSocketAddress("127.0.0.1", port), 200);
+                return port;
+            } catch (IOException e) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+            attempt++;
+        }
+        throw new IOException("server did not start listening");
+    }
+
+    private int freePort() throws IOException {
+        try (ServerSocket probe = new ServerSocket(0)) {
+            return probe.getLocalPort();
+        }
+    }
+
+    private String request(int port, String raw) throws IOException {
+        try (Socket socket = new Socket("127.0.0.1", port)) {
+            socket.setSoTimeout(5000);
+            OutputStream out = socket.getOutputStream();
+            out.write(raw.getBytes(StandardCharsets.UTF_8));
+            out.flush();
+            StringBuilder response = new StringBuilder();
+            byte[] buffer = new byte[4096];
+            int n;
+            while ((n = socket.getInputStream().read(buffer)) != -1) {
+                response.append(new String(buffer, 0, n, StandardCharsets.UTF_8));
+            }
+            return response.toString();
+        }
+    }
+
+    private static final class SseClient implements AutoCloseable {
+        private final Socket socket;
+        private final BufferedReader in;
+        final String status;
+        final List<String> headers;
+
+        SseClient(int port) throws IOException {
+            this(port, "");
+        }
+
+        SseClient(int port, String query) throws IOException {
+            socket = new Socket("127.0.0.1", port);
+            socket.setSoTimeout(2000);
+            OutputStream out = socket.getOutputStream();
+            String target = query.isEmpty() ? "/events" : "/events?" + query;
+            out.write(("GET " + target + " HTTP/1.1\r\n"
+                    + "Host: 127.0.0.1\r\n"
+                    + "Accept: text/event-stream\r\n"
+                    + "\r\n").getBytes(StandardCharsets.UTF_8));
+            out.flush();
+            in = new BufferedReader(new InputStreamReader(
+                    socket.getInputStream(), StandardCharsets.UTF_8));
+            status = in.readLine();
+            headers = new ArrayList<>();
+            String line;
+            while ((line = in.readLine()) != null && !line.isEmpty()) {
+                headers.add(line);
+            }
+        }
+
+        String header(String name) {
+            for (String line : headers) {
+                int colon = line.indexOf(':');
+                if (colon > 0 && line.substring(0, colon).trim().equalsIgnoreCase(name)) {
+                    return line.substring(colon + 1).trim();
+                }
+            }
+            return null;
+        }
+
+        String readEvent() throws IOException {
+            StringBuilder frame = new StringBuilder();
+            while (true) {
+                String line = in.readLine();
+                if (line == null) {
+                    throw new IOException("SSE stream closed before event terminator");
+                }
+                if (line.isEmpty()) return frame.toString();
+                if (frame.length() > 0) frame.append('\n');
+                frame.append(line);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            socket.close();
+        }
+    }
+
+    private SseClient connect(int port) throws IOException {
+        return new SseClient(port);
+    }
+
+    private void assertHeaders(SseClient client) {
+        assertEquals("HTTP/1.1 200 OK", client.status);
+        assertEquals("text/event-stream", client.header("Content-Type"));
+        assertEquals("no-cache", client.header("Cache-Control"));
+        assertEquals("keep-alive", client.header("Connection"));
+        assertEquals("no", client.header("X-Accel-Buffering"));
+    }
+
+    @Test
+    void single_data_event(@TempDir Path tempDir) throws Exception {
+        int port = startSseServer(tempDir, "sse.send(\"hello\")");
+        try (SseClient client = connect(port)) {
+            assertHeaders(client);
+            assertEquals("data: hello", client.readEvent());
+        }
+    }
+
+    @Test
+    void named_event(@TempDir Path tempDir) throws Exception {
+        int port = startSseServer(tempDir, "sse.event(\"tick\", \"hello\")");
+        try (SseClient client = connect(port)) {
+            assertHeaders(client);
+            assertEquals("event: tick\ndata: hello", client.readEvent());
+        }
+    }
+
+    @Test
+    void multi_event_keeps_alive(@TempDir Path tempDir) throws Exception {
+        int port = startSseServer(tempDir, """
+                sse.send("one")
+                sse.send("two")
+                sse.send("three")
+                """);
+        try (SseClient client = connect(port)) {
+            assertHeaders(client);
+            assertEquals("data: one", client.readEvent());
+            assertEquals("data: two", client.readEvent());
+            assertEquals("data: three", client.readEvent());
+        }
+    }
+
+    @Test
+    void multi_line_data_splits(@TempDir Path tempDir) throws Exception {
+        int port = startSseServer(tempDir, "sse.send(\"line1\\nline2\")");
+        try (SseClient client = connect(port)) {
+            assertHeaders(client);
+            assertEquals("data: line1\ndata: line2", client.readEvent());
+        }
+    }
+
+    @Test
+    void client_close_no_crash(@TempDir Path tempDir) throws Exception {
+        int port = startSseServer(tempDir, "sse.send(\"hello\")");
+        try (SseClient client = connect(port)) {
+            assertEquals("data: hello", client.readEvent());
+        }
+        Thread.sleep(200);
+        try (SseClient client = connect(port)) {
+            assertHeaders(client);
+            assertEquals("data: hello", client.readEvent());
+        }
+    }
+
+    @Test
+    void many_concurrent_clients_independent(@TempDir Path tempDir) throws Exception {
+        int port = startSseServer(tempDir, "sse.send(\"client-\" + query(\"client\"))");
+        ExecutorService pool = Executors.newFixedThreadPool(10);
+        try {
+            List<Future<String>> results = new ArrayList<>();
+            for (int i = 0; i < 10; i++) {
+                final int n = i;
+                results.add(pool.submit(() -> {
+                    try (SseClient client = new SseClient(port, "client=" + n)) {
+                        assertHeaders(client);
+                        return client.readEvent();
+                    }
+                }));
+            }
+            for (int i = 0; i < results.size(); i++) {
+                assertEquals("data: client-" + i,
+                        results.get(i).get(10, TimeUnit.SECONDS));
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    void hello_route_still_works(@TempDir Path tempDir) throws Exception {
+        int port = startServer(tempDir, """
+                main() {
+                    var app = web.app()
+                    app.get("/hello") { return "Hello SSE" }
+                    app.listen(PORT)
+                }
+                """);
+        String r = request(port, "GET /hello HTTP/1.1\r\nHost: x\r\n\r\n");
+        assertTrue(r.startsWith("HTTP/1.1 200 OK"), r);
+        assertTrue(r.contains("Hello SSE"), r);
+    }
+}


### PR DESCRIPTION
PR2 delivers the SSE protocol on top of PR1's persistent-connection scaffold. Stack-merged on `codex/pr1-persistent-connection` (PR #14, still open). Once #14 merges, this PR can be rebased onto `main`.

## Public API

```kof
main() {
    var app = web.app()

    app.sse("/events") {
        sse.send("connected")
        sse.event("tick", json(tick()))
        sse.close()              // optional; auto-closes when handler returns
    }

    app.listen(8080)
}
```

The trailing-block form `app.sse(path) { sse.* }` is **new sugar** introduced by this PR — see "Compiler sugar" below.

## File-by-file

| File | Change |
| --- | --- |
| `kof-compiler/.../JvmWebRuntime.java` | New `SseConnection` nested class (`send`, `event`, `close`, `isOpen`). Per-event write protected by a `ReentrantLock`, with `AtomicBoolean open` and `SocketException → open=false` fast-fail. `data` is split on `\n` and each line prefixed with `data: `, terminated by a blank line, per the SSE wire format. |
| `kof-compiler/.../JvmRuntime.java` | `kof_web_handle` branches on `RouteKind.SSE`: writes the SSE response headers (`text/event-stream`, `Cache-Control: no-cache`, `Connection: keep-alive`, `X-Accel-Buffering: no`), then dispatches the route handler in a virtual thread, joining until it returns. `WebDispatchResult` carries the matched `WebRoute` so the dispatcher can hand the handler to the runtime without a second scan. Per-connection `setSoTimeout` from PR1 is preserved. |
| `kof-compiler/.../KofWeb.java` | New `SSE_CONNECTION` synthetic type (`dev.kof.runtime.KofRuntime$SseConnection`) and `sseConnectionMethod` switch that maps `send`/`event`/`close`/`isOpen` to compile-time method shapes. Lets the compiler accept `sse.send(...)` etc. in handler bodies. |
| `kof-compiler/.../SemanticAnalyzer.java` | Adds the trailing-block sugar: `app.sse(path) { body }` is rewritten in place to `app.sse(path, (sse: KofRuntime$SseConnection) -> { body })` and the receiver-type dispatch falls through to the new `sseConnectionMethod`. |
| `kof-compiler/src/test/.../KofWebSseE2ETest.java` | **New file.** 7 E2E scenarios covering all required cases from the plan: single `data:` line, named `event:`, multi-event keeping the connection alive, multi-line data split, client close without server crash, 10 concurrent independent clients, and a sanity HTTP regression. |
| `kof-compiler/src/test/.../dev/kof/runtime/KofRuntime$SseConnection.java` *(removed)* | The earlier prototype needed a test-only stub so the Kof source could resolve `sse.*`. With the compiler sugar the real runtime nested class is reached directly, so the stub is no longer required. |

## Compiler sugar

Kof code `app.sse("/events") { sse.send("hello") }` is recognised by the parser as `app.sse(path, trailingLambda)`. The `SemanticAnalyzer` then wraps the trailing block in a one-parameter lambda whose parameter is named `sse` and typed as `KofRuntime$SseConnection`. The runtime invokes that lambda once with a fresh `SseConnection` instance over the per-socket `OutputStream`.

The same pattern will be reused for WebSocket in PR5 (`ws.onMessage`, `ws.onClose`, etc.) — it's the cleanest way to inject implicit handler parameters without disturbing AST node shapes.

## Risks captured

- **No outbound queue.** A misbehaving client can backpressure the writer; `writeFrame` catches `IOException` and marks the connection closed. PR6 may add a bounded queue.
- **No idle timeout on top of PR1's 5 min.** PR1's `KEEPALIVE_IDLE_MS` covers socket-wide idle; PR6 adds per-event deadlines.
- **Event-format pass is line-based.** A multi-line payload where one line is empty (length 0 between two `\n` chars) is rendered as `data: ` and a blank line, which the SSE spec accepts. Not a bug, but worth noting in the future SSE docs.

## Verification

```
mvn -pl kof-compiler -am test -Dtest='KofWebE2ETest,KofWebTlsTest,KofWebSseE2ETest'
→ Tests run: 22, Failures: 0, Errors: 0, Skipped: 0
→ BUILD SUCCESS

mvn -pl kof-compiler -am test (full suite)
→ 652 tests, 197 pre-existing Native backend failures on this host, JVM and TLS green.
```

The 197 Native failures are unchanged from the baseline; this PR is JVM-only.

## Out of scope (subsequent PRs)

PR3 — RFC 6455 WS handshake.
PR4 — WS frame codec.
PR5 — Idiomatic WS API, reusing the same `sse`/trailing-block sugar pattern.
PR6 — Hardening, JS/Native stubs.
PR7 — Doc sync.