### PR TITLE
feat(web): RFC 6455 WebSocket handshake

### DIFF
--- a/kof-compiler/src/main/java/dev/kof/compiler/CompilerDriver.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/CompilerDriver.java
@@ -3458,7 +3458,7 @@ private Target target = Target.JVM;
                 } else if (mc.receiver() instanceof IdentifierExpr rid && !isLocalVarName(rid.name(), locals)
                             && KofWeb.isWebNamespace(rid.name())) {
                     if ("app".equals(mc.methodName()) && mc.arguments().isEmpty()) {
-                        if (target != Target.JVM) {
+                        if (target != Target.JVM && target != Target.ANDROID) {
                             if (currentDiagnostics != null) {
                                 currentDiagnostics.error(mc.position() != null ? mc.position().file() : "",
                                         mc.position() != null ? mc.position().line() : 0,
@@ -3624,11 +3624,18 @@ private Target target = Target.JVM;
                         for (ExpressionNode arg : mc.arguments()) webArgTypes.add(inferExprType(arg, locals));
                         KofWeb.WebCall webCall = KofWeb.instanceMethod(mc.methodName(), webArgTypes);
                         if (webCall != null) {
-                            if (target != Target.JVM) {
-                                String webCode = "kof_web_listen_secure".equals(webCall.function()) ? "WEB002" : "WEB001";
-                                String webMsg = "kof_web_listen_secure".equals(webCall.function())
-                                        ? "web TLS: not available on the " + target + " target yet (WEB002)"
-                                        : "web: not available on the " + target + " target yet (WEB001)";
+                            if (target != Target.JVM && target != Target.ANDROID) {
+                                String webCode = KofWeb.gapCode(webCall.function());
+                                String webMsg = switch (webCode) {
+                                    case "WEB002" -> "web TLS: not available on the " + target
+                                            + " target yet (WEB002)";
+                                    case "WEB003" -> "web SSE: not available on the " + target
+                                            + " target yet (WEB003)";
+                                    case "WEB004" -> "web WebSocket: not available on the " + target
+                                            + " target yet (WEB004)";
+                                    default -> "web: not available on the " + target
+                                            + " target yet (WEB001)";
+                                };
                                 if (currentDiagnostics != null) {
                                     currentDiagnostics.error(mc.position() != null ? mc.position().file() : "",
                                             mc.position() != null ? mc.position().line() : 0,
@@ -3637,18 +3644,16 @@ private Target target = Target.JVM;
                                 }
                                 yield localIdx;
                             }
-                            if (KofWeb.isRouteMethod(mc.methodName())) {
-                                ops.add(new KofLoadLiteral(BuiltinTypes.STRING, mc.methodName().toUpperCase()));
-                            }
-                            for (ExpressionNode arg : mc.arguments()) {
-                                localIdx = emitExpression(arg, ops, owner, localIdx, locals);
-                            }
                             List<Type> webParams = new ArrayList<>();
                             webParams.add(BuiltinTypes.STRING);
-                            if (KofWeb.isRouteMethod(mc.methodName())) {
+                            if (KofWeb.isRouteMethod(mc.methodName()) && !"ws".equals(mc.methodName())) {
+                                ops.add(new KofLoadLiteral(BuiltinTypes.STRING, mc.methodName().toUpperCase()));
                                 webParams.add(BuiltinTypes.STRING);
                             }
-                            webParams.addAll(webCall.parameterTypes());
+                            for (ExpressionNode arg : mc.arguments()) {
+                                webParams.add(inferExprType(arg, locals));
+                                localIdx = emitExpression(arg, ops, owner, localIdx, locals);
+                            }
                             ops.add(new KofCall(KofWeb.APP, webCall.function(), webParams,
                                     webCall.returnType(), KofCallKind.FUNCTION));
                         }

--- a/kof-compiler/src/main/java/dev/kof/compiler/JvmRuntime.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/JvmRuntime.java
@@ -424,8 +424,8 @@ static boolean hasRuntimeFn(String methodName) {
                         try {
                             java.net.Socket client = app.serverSocket.accept();
                             // 15s default protects HTTP `readRequest` against
-                            // client half-open sockets. SSE/WS override this
-                            // higher inside `kof_web_keep_alive`.
+                            // client half-open sockets. WS raises this after
+                            // the handshake.
                             client.setSoTimeout(15000);
                             Thread.startVirtualThread(() -> kof_web_handle(app, client));
                         } catch (java.io.IOException e) {
@@ -518,8 +518,8 @@ static boolean hasRuntimeFn(String methodName) {
                             handler.join();
                             return;
                         }
-                        if (result.kind != RouteKind.HTTP) {
-                            kof_web_keep_alive(client);
+                        if (result.kind == RouteKind.WS) {
+                            kof_web_ws_handshake(req, client);
                             return;
                         }
                         client.getOutputStream().write(result.response.getBytes(java.nio.charset.StandardCharsets.UTF_8));
@@ -529,25 +529,61 @@ static boolean hasRuntimeFn(String methodName) {
                     }
                 }
 
-                // Idle timeout for persistent connections (SSE/WS in PR2/PR3).
-                // Without this, a client that opens the socket and never sends
-                // data would pin a virtual thread indefinitely. PR6 may move
-                // this to a configurable `web.configure(...)` knob.
+                // Idle timeout for the WS handshake stub. PR4 replaces the read
+                // loop with a frame codec and per-connection timeout handling.
                 private static final int KEEPALIVE_IDLE_MS = 300_000;
 
-                private static void kof_web_keep_alive(java.net.Socket client) throws java.io.IOException {
-                    client.setSoTimeout(KEEPALIVE_IDLE_MS);
-                    byte[] buffer = new byte[8192];
-                    try {
-                        while (client.getInputStream().read(buffer) != -1) {
-                            // PR1: no SSE/WS protocol yet; PR2/PR3 replace this with real loops.
-                            // Until then, any bytes from the client are discarded.
-                        }
-                    } catch (java.net.SocketTimeoutException idle) {
-                        // Idle socket — close cleanly. PR2 will replace this body with
-                        // real SSE/WS loops that respect the same per-read budget.
+                private static void kof_web_ws_handshake(WebRequest req, java.net.Socket client)
+                        throws java.io.IOException {
+                    String upgradeVal = req.headers.get("upgrade");
+                    String connectionVal = req.headers.get("connection");
+                    String version = req.headers.get("sec-websocket-version");
+                    String key = req.headers.get("sec-websocket-key");
+
+                    boolean hasUpgrade = containsToken(upgradeVal, "websocket");
+                    boolean hasConnection = containsToken(connectionVal, "upgrade");
+                    boolean valid = hasUpgrade
+                            && hasConnection
+                            && "13".equals(version)
+                            && key != null;
+
+                    if (!valid) {
+                        java.io.OutputStream out = client.getOutputStream();
+                        out.write("HTTP/1.1 400 Bad Request\\r\\n\\r\\n"
+                                .getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                        out.flush();
+                        return;
                     }
+
+                    String accept = wsAccept(key);
+                    java.io.OutputStream out = client.getOutputStream();
+                    out.write(("HTTP/1.1 101 Switching Protocols\\r\\n"
+                            + "Upgrade: websocket\\r\\n"
+                            + "Connection: Upgrade\\r\\n"
+                            + "Sec-WebSocket-Accept: " + accept + "\\r\\n"
+                            + "\\r\\n").getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                    out.flush();
+
+                    // Stub frame loop (PR4 substitui). Lê bytes até EOF ou timeout.
+                    client.setSoTimeout(KEEPALIVE_IDLE_MS);
+                    byte[] buf = new byte[8192];
+                    try {
+                        while (client.getInputStream().read(buf) != -1) { /* discard */ }
+                    } catch (java.net.SocketTimeoutException ignored) { /* idle */ }
                 }
+
+                    // Splits a comma-separated header value (RFC 7230 §3.2.2) into
+                    // trimmed tokens, returning true when any token equals the
+                    // expected name case-insensitively. Null/empty header -> false.
+                    // Used by WS handshake to validate Upgrade/Connection tokens
+                    // even when the same line carries unrelated tokens.
+                    private static boolean containsToken(String headerValue, String expected) {
+                        if (headerValue == null) return false;
+                        for (String token : headerValue.split(",")) {
+                            if (token.trim().equalsIgnoreCase(expected)) return true;
+                        }
+                        return false;
+                    }
 
                 private static WebDispatchResult kof_web_dispatch(WebApp app, WebRequest req) {
                     KOF_WEB_REQUEST.set(req);

--- a/kof-compiler/src/main/java/dev/kof/compiler/JvmRuntime.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/JvmRuntime.java
@@ -153,6 +153,8 @@ static boolean hasRuntimeFn(String methodName) {
             case "kof_io_dir_list" -> "(Ljava/lang/String;)Ljava/util/ArrayList;";
             case "kof_web_app_new" -> "()Ljava/lang/String;";
             case "kof_web_route" -> "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V";
+            case "kof_web_sse_route" -> "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V";
+            case "kof_web_ws_route" -> "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V";
             case "kof_web_use" -> "(Ljava/lang/String;Ljava/lang/Object;)V";
             case "kof_web_listen" -> "(Ljava/lang/String;I)V";
             case "kof_web_listen_secure" -> "(Ljava/lang/String;I)V";
@@ -326,7 +328,8 @@ static boolean hasRuntimeFn(String methodName) {
             case "kof_http_status", "kof_mq_queue_size" -> "I";
             case "kof_mq_queue" -> "Ljava/lang/String;";
             case "kof_mq_pop" -> "Ljava/lang/Object;";
-            case "kof_http_timeout_set", "kof_mq_publish", "kof_mq_subscribe", "kof_mq_unsubscribe",
+            case "kof_web_sse_route", "kof_web_ws_route", "kof_http_timeout_set",
+                    "kof_mq_publish", "kof_mq_subscribe", "kof_mq_unsubscribe",
                     "kof_mq_push", "kof_time_sleep", "kof_time_cancel", "kof_scheduler_cancel" -> "V";
             case "kof_time_now" -> "J";
             case "kof_time_interval" -> "Ljava/lang/String;";
@@ -420,6 +423,9 @@ static boolean hasRuntimeFn(String methodName) {
                     while (app.running) {
                         try {
                             java.net.Socket client = app.serverSocket.accept();
+                            // 15s default protects HTTP `readRequest` against
+                            // client half-open sockets. SSE/WS override this
+                            // higher inside `kof_web_keep_alive`.
                             client.setSoTimeout(15000);
                             Thread.startVirtualThread(() -> kof_web_handle(app, client));
                         } catch (java.io.IOException e) {
@@ -483,15 +489,39 @@ static boolean hasRuntimeFn(String methodName) {
                 private static void kof_web_handle(WebApp app, java.net.Socket client) {
                     try (client) {
                         WebRequest req = readRequest(client.getInputStream());
-                        String response = kof_web_dispatch(app, req);
-                        client.getOutputStream().write(response.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                        WebDispatchResult result = kof_web_dispatch(app, req);
+                        if (result.kind != RouteKind.HTTP) {
+                            kof_web_keep_alive(client);
+                            return;
+                        }
+                        client.getOutputStream().write(result.response.getBytes(java.nio.charset.StandardCharsets.UTF_8));
                         client.getOutputStream().flush();
                     } catch (Exception e) {
                         System.err.println("kof web connection error: " + e.getMessage());
                     }
                 }
 
-                private static String kof_web_dispatch(WebApp app, WebRequest req) {
+                // Idle timeout for persistent connections (SSE/WS in PR2/PR3).
+                // Without this, a client that opens the socket and never sends
+                // data would pin a virtual thread indefinitely. PR6 may move
+                // this to a configurable `web.configure(...)` knob.
+                private static final int KEEPALIVE_IDLE_MS = 300_000;
+
+                private static void kof_web_keep_alive(java.net.Socket client) throws java.io.IOException {
+                    client.setSoTimeout(KEEPALIVE_IDLE_MS);
+                    byte[] buffer = new byte[8192];
+                    try {
+                        while (client.getInputStream().read(buffer) != -1) {
+                            // PR1: no SSE/WS protocol yet; PR2/PR3 replace this with real loops.
+                            // Until then, any bytes from the client are discarded.
+                        }
+                    } catch (java.net.SocketTimeoutException idle) {
+                        // Idle socket — close cleanly. PR2 will replace this body with
+                        // real SSE/WS loops that respect the same per-read budget.
+                    }
+                }
+
+                private static WebDispatchResult kof_web_dispatch(WebApp app, WebRequest req) {
                     KOF_WEB_REQUEST.set(req);
                     KOF_WEB_STATUS.remove();
                     KOF_WEB_HEADERS.get().clear();
@@ -506,11 +536,11 @@ static boolean hasRuntimeFn(String methodName) {
                                 String resp = kof_web_build(code, text, String.valueOf(result));
                                 KOF_WEB_STATUS.remove();
                                 KOF_WEB_HEADERS.get().clear();
-                                return resp;
+                                return new WebDispatchResult(RouteKind.HTTP, resp);
                             }
                         }
                         for (WebRoute route : app.routes) {
-                            if (!route.method.equals(req.method)) continue;
+                            if (route.kind == RouteKind.HTTP && !route.method.equals(req.method)) continue;
                             String[] pathSegs = req.path.split("/");
                             if (pathSegs.length != route.segments.length) continue;
                             boolean match = true;
@@ -525,13 +555,19 @@ static boolean hasRuntimeFn(String methodName) {
                             }
                             if (!match) continue;
                             req.params.putAll(params);
+                            if (route.kind != RouteKind.HTTP) {
+                                KOF_WEB_STATUS.remove();
+                                KOF_WEB_HEADERS.get().clear();
+                                return new WebDispatchResult(route.kind, null);
+                            }
                             KOF_WEB_STATUS.remove();
                             KOF_WEB_HEADERS.get().clear();
                             Object result = kof_web_invoke(route.handler, req);
                             if (result == null) {
                                 KOF_WEB_STATUS.remove();
                                 KOF_WEB_HEADERS.get().clear();
-                                return kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}");
+                                return new WebDispatchResult(RouteKind.HTTP,
+                                        kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}"));
                             }
                             Integer st2 = KOF_WEB_STATUS.get();
                             int code2 = st2 != null ? st2 : 200;
@@ -539,15 +575,17 @@ static boolean hasRuntimeFn(String methodName) {
                             String resp2 = kof_web_build(code2, text2, String.valueOf(result));
                             KOF_WEB_STATUS.remove();
                             KOF_WEB_HEADERS.get().clear();
-                            return resp2;
+                            return new WebDispatchResult(RouteKind.HTTP, resp2);
                         }
-                        return kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}");
+                        return new WebDispatchResult(RouteKind.HTTP,
+                                kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}"));
                     } catch (Exception e) {
                         String msg = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
                         KOF_WEB_STATUS.remove();
                         KOF_WEB_HEADERS.get().clear();
-                        return kof_web_build(500, "Internal Server Error",
-                                "{\\"error\\": \\"handler error: " + msg + "\\"}");
+                        return new WebDispatchResult(RouteKind.HTTP,
+                                kof_web_build(500, "Internal Server Error",
+                                        "{\\"error\\": \\"handler error: " + msg + "\\"}"));
                     } finally {
                         KOF_WEB_REQUEST.remove();
                         KOF_LOG_REQUEST_ID.remove();

--- a/kof-compiler/src/main/java/dev/kof/compiler/JvmRuntime.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/JvmRuntime.java
@@ -490,6 +490,34 @@ static boolean hasRuntimeFn(String methodName) {
                     try (client) {
                         WebRequest req = readRequest(client.getInputStream());
                         WebDispatchResult result = kof_web_dispatch(app, req);
+                        if (result.kind == RouteKind.SSE) {
+                            java.io.OutputStream out = client.getOutputStream();
+                            out.write(("HTTP/1.1 200 OK\\r\\n"
+                                    + "Content-Type: text/event-stream\\r\\n"
+                                    + "Cache-Control: no-cache\\r\\n"
+                                    + "Connection: keep-alive\\r\\n"
+                                    + "X-Accel-Buffering: no\\r\\n"
+                                    + "\\r\\n").getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                            out.flush();
+                            SseConnection sse = new SseConnection(out);
+                            Thread handler = Thread.startVirtualThread(() -> {
+                                try {
+                                    KOF_WEB_REQUEST.set(req);
+                                    try {
+                                        kof_web_invoke(result.route.handler, sse);
+                                    } finally {
+                                        KOF_WEB_REQUEST.remove();
+                                    }
+                                } catch (Exception e) {
+                                    System.err.println("kof web sse handler error: "
+                                            + e.getMessage());
+                                } finally {
+                                    sse.close();
+                                }
+                            });
+                            handler.join();
+                            return;
+                        }
                         if (result.kind != RouteKind.HTTP) {
                             kof_web_keep_alive(client);
                             return;
@@ -536,7 +564,7 @@ static boolean hasRuntimeFn(String methodName) {
                                 String resp = kof_web_build(code, text, String.valueOf(result));
                                 KOF_WEB_STATUS.remove();
                                 KOF_WEB_HEADERS.get().clear();
-                                return new WebDispatchResult(RouteKind.HTTP, resp);
+                                return new WebDispatchResult(RouteKind.HTTP, resp, null);
                             }
                         }
                         for (WebRoute route : app.routes) {
@@ -558,7 +586,7 @@ static boolean hasRuntimeFn(String methodName) {
                             if (route.kind != RouteKind.HTTP) {
                                 KOF_WEB_STATUS.remove();
                                 KOF_WEB_HEADERS.get().clear();
-                                return new WebDispatchResult(route.kind, null);
+                                return new WebDispatchResult(route.kind, null, route);
                             }
                             KOF_WEB_STATUS.remove();
                             KOF_WEB_HEADERS.get().clear();
@@ -567,7 +595,7 @@ static boolean hasRuntimeFn(String methodName) {
                                 KOF_WEB_STATUS.remove();
                                 KOF_WEB_HEADERS.get().clear();
                                 return new WebDispatchResult(RouteKind.HTTP,
-                                        kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}"));
+                                        kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}"), null);
                             }
                             Integer st2 = KOF_WEB_STATUS.get();
                             int code2 = st2 != null ? st2 : 200;
@@ -575,17 +603,17 @@ static boolean hasRuntimeFn(String methodName) {
                             String resp2 = kof_web_build(code2, text2, String.valueOf(result));
                             KOF_WEB_STATUS.remove();
                             KOF_WEB_HEADERS.get().clear();
-                            return new WebDispatchResult(RouteKind.HTTP, resp2);
+                            return new WebDispatchResult(RouteKind.HTTP, resp2, null);
                         }
                         return new WebDispatchResult(RouteKind.HTTP,
-                                kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}"));
+                                kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}"), null);
                     } catch (Exception e) {
                         String msg = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
                         KOF_WEB_STATUS.remove();
                         KOF_WEB_HEADERS.get().clear();
                         return new WebDispatchResult(RouteKind.HTTP,
                                 kof_web_build(500, "Internal Server Error",
-                                        "{\\"error\\": \\"handler error: " + msg + "\\"}"));
+                                        "{\\"error\\": \\"handler error: " + msg + "\\"}"), null);
                     } finally {
                         KOF_WEB_REQUEST.remove();
                         KOF_LOG_REQUEST_ID.remove();
@@ -603,6 +631,11 @@ static boolean hasRuntimeFn(String methodName) {
                                         String.class, String.class)
                                 .invoke(target, req.method, req.path, req.body, req.query, req.rawHeaders);
                     }
+                }
+
+                private static Object kof_web_invoke(Object target, SseConnection sse) throws Exception {
+                    return target.getClass().getMethod("invoke", SseConnection.class)
+                            .invoke(target, sse);
                 }
 
                 private static String kof_web_build(int status, String statusText, String body) {

--- a/kof-compiler/src/main/java/dev/kof/compiler/JvmWebRuntime.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/JvmWebRuntime.java
@@ -58,7 +58,7 @@ final class JvmWebRuntime {
 
                 public enum RouteKind { HTTP, SSE, WS }
 
-                record WebDispatchResult(RouteKind kind, String response) {}
+                record WebDispatchResult(RouteKind kind, String response, WebRoute route) {}
 
                 public static final class WebRoute {
                     final String method;
@@ -124,6 +124,65 @@ final class JvmWebRuntime {
 
                     String header(String name) {
                         return headers.get(name.toLowerCase());
+                    }
+                }
+
+                public static final class SseConnection {
+                    private final java.io.OutputStream out;
+                    private final byte[] nl = "\\n".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                    private final java.util.concurrent.atomic.AtomicBoolean open =
+                            new java.util.concurrent.atomic.AtomicBoolean(true);
+                    private final java.util.concurrent.locks.ReentrantLock writeLock =
+                            new java.util.concurrent.locks.ReentrantLock();
+
+                    SseConnection(java.io.OutputStream out) {
+                        this.out = out;
+                    }
+
+                    public void send(String data) {
+                        writeData(data);
+                    }
+
+                    public void event(String name, String data) {
+                        writeFrame("event: " + name + "\\n");
+                        writeData(data);
+                    }
+
+                    public void close() {
+                        if (open.compareAndSet(true, false)) {
+                            writeLock.lock();
+                            try {
+                                out.flush();
+                                out.close();
+                            } catch (java.io.IOException ignored) {
+                            } finally {
+                                writeLock.unlock();
+                            }
+                        }
+                    }
+
+                    public boolean isOpen() {
+                        return open.get();
+                    }
+
+                    private void writeData(String data) {
+                        for (String line : data.split("\\n", -1)) {
+                            writeFrame("data: " + line + "\\n");
+                        }
+                        writeFrame("\\n");
+                    }
+
+                    private void writeFrame(String frame) {
+                        if (!open.get()) return;
+                        writeLock.lock();
+                        try {
+                            out.write(frame.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                            out.flush();
+                        } catch (java.io.IOException e) {
+                            open.set(false);
+                        } finally {
+                            writeLock.unlock();
+                        }
                     }
                 }
 

--- a/kof-compiler/src/main/java/dev/kof/compiler/JvmWebRuntime.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/JvmWebRuntime.java
@@ -56,13 +56,19 @@ final class JvmWebRuntime {
                     };
                 }
 
+                public enum RouteKind { HTTP, SSE, WS }
+
+                record WebDispatchResult(RouteKind kind, String response) {}
+
                 public static final class WebRoute {
                     final String method;
                     final String[] segments;
                     final boolean[] params;
                     final Object handler;
+                    final RouteKind kind;
 
-                    WebRoute(String method, String path, Object handler) {
+                    WebRoute(RouteKind kind, String method, String path, Object handler) {
+                        this.kind = kind;
                         this.method = method;
                         String[] raw = path.split("/");
                         this.segments = new String[raw.length];
@@ -148,9 +154,23 @@ final class JvmWebRuntime {
                 public static void kof_web_route(String appId, String method, String path, Object handler) {
                     if (handler == null) throw new IllegalArgumentException("route handler is null");
                     String m = method.toUpperCase();
-                    if ("WS".equals(m)) m = "GET";
-                    if ("SSE".equals(m)) m = "GET";
-                    kof_web_app(appId).routes.add(new WebRoute(m, path, handler));
+                    if ("SSE".equals(m) || "WS".equals(m)) {
+                        throw new IllegalArgumentException(
+                                "route method " + m + " requires kof_web_sse_route/kof_web_ws_route");
+                    }
+                    kof_web_app(appId).routes.add(new WebRoute(RouteKind.HTTP, m, path, handler));
+                }
+
+                public static void kof_web_sse_route(String appId, String method, String path, Object handler) {
+                    if (handler == null) throw new IllegalArgumentException("route handler is null");
+                    kof_web_app(appId).routes.add(
+                            new WebRoute(RouteKind.SSE, method.toUpperCase(), path, handler));
+                }
+
+                public static void kof_web_ws_route(String appId, String path, Object handler) {
+                    if (handler == null) throw new IllegalArgumentException("route handler is null");
+                    kof_web_app(appId).routes.add(
+                            new WebRoute(RouteKind.WS, "WS", path, handler));
                 }
 
                 public static void kof_web_use(String appId, Object handler) {

--- a/kof-compiler/src/main/java/dev/kof/compiler/JvmWebRuntime.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/JvmWebRuntime.java
@@ -56,6 +56,17 @@ final class JvmWebRuntime {
                     };
                 }
 
+                public static String wsAccept(String secWebSocketKey) {
+                    try {
+                        String concat = secWebSocketKey + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+                        java.security.MessageDigest sha1 = java.security.MessageDigest.getInstance("SHA-1");
+                        byte[] hash = sha1.digest(concat.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                        return java.util.Base64.getEncoder().encodeToString(hash);
+                    } catch (Exception e) {
+                        throw new RuntimeException("SHA-1 unavailable on JVM", e);
+                    }
+                }
+
                 public enum RouteKind { HTTP, SSE, WS }
 
                 record WebDispatchResult(RouteKind kind, String response, WebRoute route) {}

--- a/kof-compiler/src/main/java/dev/kof/compiler/KofWeb.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/KofWeb.java
@@ -25,6 +25,8 @@ final class KofWeb {
     private KofWeb() {}
 
     static final Type APP = new Type.ClassType("kof.web", "App", List.of());
+    static final Type SSE_CONNECTION =
+            new Type.ClassType("dev.kof.runtime", "KofRuntime$SseConnection", List.of());
 
     private static final Type STR = BuiltinTypes.STRING;
     private static final Type INT = Type.PrimitiveType.INT;
@@ -36,6 +38,25 @@ final class KofWeb {
 
     static boolean isAppType(Type t) {
         return APP.equals(t);
+    }
+
+    static boolean isSseConnectionType(Type t) {
+        return SSE_CONNECTION.equals(t);
+    }
+
+    /** Methods available on the synthetic {@code sse} handler parameter. */
+    static WebCall sseConnectionMethod(String name, List<Type> argTypes) {
+        return switch (name) {
+            case "send" -> argTypes.size() == 1
+                    ? new WebCall(name, VOID, argTypes) : null;
+            case "event" -> argTypes.size() == 2
+                    ? new WebCall(name, VOID, argTypes) : null;
+            case "close" -> argTypes.isEmpty()
+                    ? new WebCall(name, VOID, List.of()) : null;
+            case "isOpen" -> argTypes.isEmpty()
+                    ? new WebCall(name, Type.PrimitiveType.BOOL, List.of()) : null;
+            default -> null;
+        };
     }
 
     static boolean isWebNamespace(String name) {

--- a/kof-compiler/src/main/java/dev/kof/compiler/KofWeb.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/KofWeb.java
@@ -68,6 +68,12 @@ final class KofWeb {
     /** Instance methods on {@code kof.web.App} receivers. */
     static WebCall instanceMethod(String name, List<Type> argTypes) {
         if (ROUTE_METHODS.contains(name)) {
+            if ("sse".equals(name)) {
+                return instanceSseMethod(name, argTypes);
+            }
+            if ("ws".equals(name)) {
+                return instanceWsMethod(name, argTypes);
+            }
             if (argTypes.size() == 2) {
                 return new WebCall("kof_web_route", VOID,
                         List.of(STR, STR, STR, argTypes.get(1)));
@@ -91,6 +97,34 @@ final class KofWeb {
                     ? new WebCall("kof_web_close", VOID, List.of(STR))
                     : null;
             default -> null;
+        };
+    }
+
+
+    /** {@code app.sse(path, handler)} — route kind SSE, protocol comes later. */
+    static WebCall instanceSseMethod(String name, List<Type> argTypes) {
+        return "sse".equals(name) && argTypes.size() == 2
+                ? new WebCall("kof_web_sse_route", VOID,
+                        List.of(STR, STR, STR, argTypes.get(1)))
+                : null;
+    }
+
+
+    /** {@code app.ws(path, handler)} — route kind WS, protocol comes later. */
+    static WebCall instanceWsMethod(String name, List<Type> argTypes) {
+        return "ws".equals(name) && argTypes.size() == 2
+                ? new WebCall("kof_web_ws_route", VOID,
+                        List.of(STR, STR, argTypes.get(1)))
+                : null;
+    }
+
+
+    static String gapCode(String function) {
+        return switch (function) {
+            case "kof_web_sse_route" -> "WEB003";
+            case "kof_web_ws_route" -> "WEB004";
+            case "kof_web_listen_secure" -> "WEB002";
+            default -> "WEB001";
         };
     }
 

--- a/kof-compiler/src/main/java/dev/kof/compiler/SemanticAnalyzer.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/SemanticAnalyzer.java
@@ -8,6 +8,9 @@ import java.util.Map;
 
 class SemanticAnalyzer {
 
+    private static final String SSE_CONNECTION_TYPE =
+            "dev.kof.runtime.KofRuntime$SseConnection";
+
     private SymbolTable currentScope;
     private CompilationUnitNode currentUnit;
 
@@ -1193,10 +1196,24 @@ class SemanticAnalyzer {
                         yield KofWeb.APP;
                     }
                     if (KofWeb.isAppType(recvType)) {
+                        if ("sse".equals(mc.methodName()) && mc.arguments().size() == 2
+                                && mc.arguments().get(1) instanceof LambdaExpr le
+                                && le.parameters().isEmpty()) {
+                            mc.arguments().set(1, new LambdaExpr(le.position(),
+                                    List.of(new FormalParameterNode(le.position(), List.of(),
+                                            SSE_CONNECTION_TYPE, "sse")), le.body()));
+                        }
                         List<Type> argTypes = new ArrayList<>();
                         for (ExpressionNode arg : mc.arguments()) argTypes.add(inferType(arg, scope));
                         KofWeb.WebCall webCall = KofWeb.instanceMethod(mc.methodName(), argTypes);
                         if (webCall != null) yield webCall.returnType();
+                        yield Type.UnknownType.UNKNOWN;
+                    }
+                    if (KofWeb.isSseConnectionType(recvType)) {
+                        List<Type> argTypes = new ArrayList<>();
+                        for (ExpressionNode arg : mc.arguments()) argTypes.add(inferType(arg, scope));
+                        KofWeb.WebCall sseCall = KofWeb.sseConnectionMethod(mc.methodName(), argTypes);
+                        if (sseCall != null) yield sseCall.returnType();
                         yield Type.UnknownType.UNKNOWN;
                     }
                     if (recvType instanceof Type.FunctionType ft) {

--- a/kof-compiler/src/test/java/dev/kof/compiler/KofWebE2ETest.java
+++ b/kof-compiler/src/test/java/dev/kof/compiler/KofWebE2ETest.java
@@ -221,4 +221,22 @@ class KofWebE2ETest {
         assertEquals("A", bodyOf(request(port, "GET /a HTTP/1.1\r\nHost: x\r\n\r\n")));
         assertEquals("B", bodyOf(request(port, "GET /b HTTP/1.1\r\nHost: x\r\n\r\n")));
     }
+
+    @Test
+    void sseAndWsGapOnNative(@TempDir Path tempDir) throws IOException {
+        Path source = tempDir.resolve("App.kf");
+        Files.writeString(source, """
+                main() {
+                    var app = web.app()
+                    app.sse("/events") { return "x" }
+                    app.ws("/chat") { return "x" }
+                }
+                """);
+        CompilationResult result = driver.compile(source, tempDir.resolve("out"), Target.NATIVE);
+        var diagnostics = result.diagnostics().getDiagnostics();
+        assertTrue(diagnostics.stream().anyMatch(d -> d.code().equals("WEB003")),
+                "Should have WEB003, got: " + diagnostics);
+        assertTrue(diagnostics.stream().anyMatch(d -> d.code().equals("WEB004")),
+                "Should have WEB004, got: " + diagnostics);
+    }
 }

--- a/kof-compiler/src/test/java/dev/kof/compiler/KofWebSseE2ETest.java
+++ b/kof-compiler/src/test/java/dev/kof/compiler/KofWebSseE2ETest.java
@@ -1,0 +1,290 @@
+package dev.kof.compiler;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * E2E tests for the Kof-native SSE stack ({@code app.sse(...)}).
+ */
+class KofWebSseE2ETest {
+
+    private static final String JAVA_BIN = Path.of(
+            System.getProperty("java.home"), "bin", "java").toString();
+
+    private Process serverProcess;
+
+    @AfterEach
+    void stopServer() {
+        if (serverProcess != null) {
+            serverProcess.destroy();
+            try {
+                serverProcess.waitFor(5, TimeUnit.SECONDS);
+            } catch (InterruptedException ignored) {
+            }
+            serverProcess.destroyForcibly();
+            serverProcess = null;
+        }
+    }
+
+    private static final String SSE_APP = """
+            main() {
+                var app = web.app()
+                app.sse("/events") {
+                    HANDLER
+                }
+                app.listen(PORT)
+            }
+            """;
+
+    private static Path testClassesDir() throws Exception {
+        return Path.of(KofWebSseE2ETest.class.getProtectionDomain()
+                .getCodeSource().getLocation().toURI()).toRealPath();
+    }
+
+    private int startSseServer(Path tempDir, String handlerBody) throws Exception {
+        return startServer(tempDir, SSE_APP.replace("HANDLER", handlerBody));
+    }
+
+    private int startServer(Path tempDir, String kofSource) throws Exception {
+        int port = freePort();
+        Path sourceFile = tempDir.resolve("App.kf");
+        Files.writeString(sourceFile, kofSource.replace("PORT", String.valueOf(port)));
+        Path outDir = tempDir.resolve("classes");
+        CompilerDriver driver = new CompilerDriver();
+        driver.setExternalClasspath(List.of(testClassesDir()));
+        CompilationResult result = driver.compile(sourceFile, outDir, Target.JVM);
+        assertTrue(result.success(), "Compilation should succeed: "
+                + result.diagnostics().getDiagnostics());
+        ProcessBuilder pb = new ProcessBuilder(JAVA_BIN, "-cp", outDir.toString(), "Default.Main");
+        pb.redirectErrorStream(true);
+        serverProcess = pb.start();
+        int attempt = 0;
+        while (attempt < 40) {
+            if (!serverProcess.isAlive()) {
+                String out = new String(serverProcess.getInputStream().readAllBytes(),
+                                StandardCharsets.UTF_8)
+                        .replace("\r\n", "\n").trim();
+                throw new IOException("server exited early: " + out);
+            }
+            try (Socket probe = new Socket()) {
+                probe.connect(new java.net.InetSocketAddress("127.0.0.1", port), 200);
+                return port;
+            } catch (IOException e) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+            attempt++;
+        }
+        throw new IOException("server did not start listening");
+    }
+
+    private int freePort() throws IOException {
+        try (ServerSocket probe = new ServerSocket(0)) {
+            return probe.getLocalPort();
+        }
+    }
+
+    private String request(int port, String raw) throws IOException {
+        try (Socket socket = new Socket("127.0.0.1", port)) {
+            socket.setSoTimeout(5000);
+            OutputStream out = socket.getOutputStream();
+            out.write(raw.getBytes(StandardCharsets.UTF_8));
+            out.flush();
+            StringBuilder response = new StringBuilder();
+            byte[] buffer = new byte[4096];
+            int n;
+            while ((n = socket.getInputStream().read(buffer)) != -1) {
+                response.append(new String(buffer, 0, n, StandardCharsets.UTF_8));
+            }
+            return response.toString();
+        }
+    }
+
+    private static final class SseClient implements AutoCloseable {
+        private final Socket socket;
+        private final BufferedReader in;
+        final String status;
+        final List<String> headers;
+
+        SseClient(int port) throws IOException {
+            this(port, "");
+        }
+
+        SseClient(int port, String query) throws IOException {
+            socket = new Socket("127.0.0.1", port);
+            socket.setSoTimeout(2000);
+            OutputStream out = socket.getOutputStream();
+            String target = query.isEmpty() ? "/events" : "/events?" + query;
+            out.write(("GET " + target + " HTTP/1.1\r\n"
+                    + "Host: 127.0.0.1\r\n"
+                    + "Accept: text/event-stream\r\n"
+                    + "\r\n").getBytes(StandardCharsets.UTF_8));
+            out.flush();
+            in = new BufferedReader(new InputStreamReader(
+                    socket.getInputStream(), StandardCharsets.UTF_8));
+            status = in.readLine();
+            headers = new ArrayList<>();
+            String line;
+            while ((line = in.readLine()) != null && !line.isEmpty()) {
+                headers.add(line);
+            }
+        }
+
+        String header(String name) {
+            for (String line : headers) {
+                int colon = line.indexOf(':');
+                if (colon > 0 && line.substring(0, colon).trim().equalsIgnoreCase(name)) {
+                    return line.substring(colon + 1).trim();
+                }
+            }
+            return null;
+        }
+
+        String readEvent() throws IOException {
+            StringBuilder frame = new StringBuilder();
+            while (true) {
+                String line = in.readLine();
+                if (line == null) {
+                    throw new IOException("SSE stream closed before event terminator");
+                }
+                if (line.isEmpty()) return frame.toString();
+                if (frame.length() > 0) frame.append('\n');
+                frame.append(line);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            socket.close();
+        }
+    }
+
+    private SseClient connect(int port) throws IOException {
+        return new SseClient(port);
+    }
+
+    private void assertHeaders(SseClient client) {
+        assertEquals("HTTP/1.1 200 OK", client.status);
+        assertEquals("text/event-stream", client.header("Content-Type"));
+        assertEquals("no-cache", client.header("Cache-Control"));
+        assertEquals("keep-alive", client.header("Connection"));
+        assertEquals("no", client.header("X-Accel-Buffering"));
+    }
+
+    @Test
+    void single_data_event(@TempDir Path tempDir) throws Exception {
+        int port = startSseServer(tempDir, "sse.send(\"hello\")");
+        try (SseClient client = connect(port)) {
+            assertHeaders(client);
+            assertEquals("data: hello", client.readEvent());
+        }
+    }
+
+    @Test
+    void named_event(@TempDir Path tempDir) throws Exception {
+        int port = startSseServer(tempDir, "sse.event(\"tick\", \"hello\")");
+        try (SseClient client = connect(port)) {
+            assertHeaders(client);
+            assertEquals("event: tick\ndata: hello", client.readEvent());
+        }
+    }
+
+    @Test
+    void multi_event_keeps_alive(@TempDir Path tempDir) throws Exception {
+        int port = startSseServer(tempDir, """
+                sse.send("one")
+                sse.send("two")
+                sse.send("three")
+                """);
+        try (SseClient client = connect(port)) {
+            assertHeaders(client);
+            assertEquals("data: one", client.readEvent());
+            assertEquals("data: two", client.readEvent());
+            assertEquals("data: three", client.readEvent());
+        }
+    }
+
+    @Test
+    void multi_line_data_splits(@TempDir Path tempDir) throws Exception {
+        int port = startSseServer(tempDir, "sse.send(\"line1\\nline2\")");
+        try (SseClient client = connect(port)) {
+            assertHeaders(client);
+            assertEquals("data: line1\ndata: line2", client.readEvent());
+        }
+    }
+
+    @Test
+    void client_close_no_crash(@TempDir Path tempDir) throws Exception {
+        int port = startSseServer(tempDir, "sse.send(\"hello\")");
+        try (SseClient client = connect(port)) {
+            assertEquals("data: hello", client.readEvent());
+        }
+        Thread.sleep(200);
+        try (SseClient client = connect(port)) {
+            assertHeaders(client);
+            assertEquals("data: hello", client.readEvent());
+        }
+    }
+
+    @Test
+    void many_concurrent_clients_independent(@TempDir Path tempDir) throws Exception {
+        int port = startSseServer(tempDir, "sse.send(\"client-\" + query(\"client\"))");
+        ExecutorService pool = Executors.newFixedThreadPool(10);
+        try {
+            List<Future<String>> results = new ArrayList<>();
+            for (int i = 0; i < 10; i++) {
+                final int n = i;
+                results.add(pool.submit(() -> {
+                    try (SseClient client = new SseClient(port, "client=" + n)) {
+                        assertHeaders(client);
+                        return client.readEvent();
+                    }
+                }));
+            }
+            for (int i = 0; i < results.size(); i++) {
+                assertEquals("data: client-" + i,
+                        results.get(i).get(10, TimeUnit.SECONDS));
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    void hello_route_still_works(@TempDir Path tempDir) throws Exception {
+        int port = startServer(tempDir, """
+                main() {
+                    var app = web.app()
+                    app.get("/hello") { return "Hello SSE" }
+                    app.listen(PORT)
+                }
+                """);
+        String r = request(port, "GET /hello HTTP/1.1\r\nHost: x\r\n\r\n");
+        assertTrue(r.startsWith("HTTP/1.1 200 OK"), r);
+        assertTrue(r.contains("Hello SSE"), r);
+    }
+}

--- a/kof-compiler/src/test/java/dev/kof/compiler/KofWebWsE2ETest.java
+++ b/kof-compiler/src/test/java/dev/kof/compiler/KofWebWsE2ETest.java
@@ -1,0 +1,280 @@
+package dev.kof.compiler;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * E2E tests for the RFC 6455 WebSocket handshake in the Kof-native web stack.
+ */
+class KofWebWsE2ETest {
+
+    private static final String JAVA_BIN = Path.of(
+            System.getProperty("java.home"), "bin", "java").toString();
+
+    private static final String VALID_HEADERS = "Upgrade: websocket\r\n"
+            + "Connection: Upgrade\r\n"
+            + "Sec-WebSocket-Version: 13\r\n"
+            + "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n";
+
+    private Process serverProcess;
+
+    @AfterEach
+    void stopServer() {
+        if (serverProcess != null) {
+            serverProcess.destroy();
+            try {
+                serverProcess.waitFor(5, TimeUnit.SECONDS);
+            } catch (InterruptedException ignored) {
+            }
+            serverProcess.destroyForcibly();
+            serverProcess = null;
+        }
+    }
+
+    private static Path testClassesDir() throws Exception {
+        return Path.of(KofWebWsE2ETest.class.getProtectionDomain()
+                .getCodeSource().getLocation().toURI()).toRealPath();
+    }
+
+    private int startServer(Path tempDir, String kofSource) throws Exception {
+        int port = freePort();
+        Path sourceFile = tempDir.resolve("App.kf");
+        Files.writeString(sourceFile, kofSource.replace("PORT", String.valueOf(port)));
+        Path outDir = tempDir.resolve("classes");
+        CompilerDriver driver = new CompilerDriver();
+        driver.setExternalClasspath(List.of(testClassesDir()));
+        CompilationResult result = driver.compile(sourceFile, outDir, Target.JVM);
+        assertTrue(result.success(), "Compilation should succeed: "
+                + result.diagnostics().getDiagnostics());
+        ProcessBuilder pb = new ProcessBuilder(JAVA_BIN, "-cp", outDir.toString(), "Default.Main");
+        pb.redirectErrorStream(true);
+        serverProcess = pb.start();
+        int attempt = 0;
+        while (attempt < 40) {
+            if (!serverProcess.isAlive()) {
+                String out = new String(serverProcess.getInputStream().readAllBytes(),
+                                StandardCharsets.UTF_8)
+                        .replace("\r\n", "\n").trim();
+                throw new IOException("server exited early: " + out);
+            }
+            try (Socket probe = new Socket()) {
+                probe.connect(new java.net.InetSocketAddress("127.0.0.1", port), 200);
+                return port;
+            } catch (IOException e) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+            attempt++;
+        }
+        throw new IOException("server did not start listening");
+    }
+
+    private int freePort() throws IOException {
+        try (ServerSocket probe = new ServerSocket(0)) {
+            return probe.getLocalPort();
+        }
+    }
+
+    private String request(int port, String raw) throws IOException {
+        try (Socket socket = new Socket("127.0.0.1", port)) {
+            socket.setSoTimeout(5000);
+            OutputStream out = socket.getOutputStream();
+            out.write(raw.getBytes(StandardCharsets.UTF_8));
+            out.flush();
+            StringBuilder response = new StringBuilder();
+            byte[] buffer = new byte[4096];
+            int n;
+            while ((n = socket.getInputStream().read(buffer)) != -1) {
+                response.append(new String(buffer, 0, n, StandardCharsets.UTF_8));
+            }
+            return response.toString();
+        }
+    }
+
+    private static final class WsResponse implements AutoCloseable {
+        private final Socket socket;
+        private final String status;
+        private final List<String> headers;
+
+        WsResponse(Socket socket, String status, List<String> headers) {
+            this.socket = socket;
+            this.status = status;
+            this.headers = headers;
+        }
+
+        String header(String name) {
+            for (String line : headers) {
+                int colon = line.indexOf(':');
+                if (colon > 0 && line.substring(0, colon).trim().equalsIgnoreCase(name)) {
+                    return line.substring(colon + 1).trim();
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public void close() throws IOException {
+            socket.close();
+        }
+    }
+
+    private WsResponse handshake(int port, String extraHeaders) throws IOException {
+        Socket socket = new Socket("127.0.0.1", port);
+        socket.setSoTimeout(5000);
+        OutputStream out = socket.getOutputStream();
+        out.write(("GET /ws HTTP/1.1\r\nHost: x\r\n"
+                + extraHeaders
+                + "\r\n").getBytes(StandardCharsets.UTF_8));
+        out.flush();
+        BufferedReader in = new BufferedReader(new InputStreamReader(
+                socket.getInputStream(), StandardCharsets.UTF_8));
+        String status = in.readLine();
+        List<String> headers = new ArrayList<>();
+        String line;
+        while ((line = in.readLine()) != null && !line.isEmpty()) {
+            headers.add(line);
+        }
+        return new WsResponse(socket, status, headers);
+    }
+
+    private String wsApp() {
+        return """
+                main() {
+                    var app = web.app()
+                    app.ws("/ws") { return "x" }
+                    app.listen(PORT)
+                }
+                """;
+    }
+
+    @Test
+    void handshake_101_with_correct_accept(@TempDir Path tempDir) throws Exception {
+        int port = startServer(tempDir, wsApp());
+        try (WsResponse response = handshake(port, VALID_HEADERS)) {
+            assertEquals("HTTP/1.1 101 Switching Protocols", response.status);
+            assertEquals("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=",
+                    response.header("Sec-WebSocket-Accept"));
+        }
+    }
+
+    @Test
+    void handshake_rejects_missing_key(@TempDir Path tempDir) throws Exception {
+        int port = startServer(tempDir, wsApp());
+        String response = request(port, "GET /ws HTTP/1.1\r\nHost: x\r\n"
+                + "Upgrade: websocket\r\n"
+                + "Connection: Upgrade\r\n"
+                + "Sec-WebSocket-Version: 13\r\n"
+                + "\r\n");
+        assertTrue(response.startsWith("HTTP/1.1 400 Bad Request"), response);
+    }
+
+    @Test
+    void handshake_rejects_old_version(@TempDir Path tempDir) throws Exception {
+        int port = startServer(tempDir, wsApp());
+        String response = request(port, "GET /ws HTTP/1.1\r\nHost: x\r\n"
+                + VALID_HEADERS.replace("Version: 13", "Version: 8")
+                + "\r\n");
+        assertTrue(response.startsWith("HTTP/1.1 400 Bad Request"), response);
+    }
+
+    @Test
+    void handshake_rejects_no_upgrade(@TempDir Path tempDir) throws Exception {
+        int port = startServer(tempDir, wsApp());
+        String response = request(port, "GET /ws HTTP/1.1\r\nHost: x\r\n"
+                + "Connection: Upgrade\r\n"
+                + "Sec-WebSocket-Version: 13\r\n"
+                + "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+                + "\r\n");
+        assertTrue(response.startsWith("HTTP/1.1 400 Bad Request"), response);
+    }
+
+    @Test
+    void handshake_rejects_no_connection_upgrade(@TempDir Path tempDir) throws Exception {
+        int port = startServer(tempDir, wsApp());
+        String response = request(port, "GET /ws HTTP/1.1\r\nHost: x\r\n"
+                + "Upgrade: websocket\r\n"
+                + "Sec-WebSocket-Version: 13\r\n"
+                + "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+                + "\r\n");
+        assertTrue(response.startsWith("HTTP/1.1 400 Bad Request"), response);
+    }
+
+    @Test
+    void handshake_keeps_socket_open(@TempDir Path tempDir) throws Exception {
+        int port = startServer(tempDir, wsApp());
+        try (WsResponse response = handshake(port, VALID_HEADERS)) {
+            assertEquals("HTTP/1.1 101 Switching Protocols", response.status);
+            Thread.sleep(300);
+            assertTrue(serverProcess.isAlive());
+            assertFalse(response.socket.isClosed());
+            assertEquals(0, response.socket.getInputStream().available());
+        }
+    }
+
+    /**
+     * Validates the case the previous substring-based validator broke:
+     * {@code Connection: keep-alive, Upgrade} carries the Upgrade token in a
+     * comma-separated list, not as the only value. RFC 6455 §4.1 requires it
+     * to be accepted.
+     */
+    @Test
+    void handshake_accepts_comma_separated_connection_tokens(@TempDir Path tempDir) throws Exception {
+        String headers = "Upgrade: websocket\r\n"
+                + "Connection: keep-alive, Upgrade\r\n"
+                + "Sec-WebSocket-Version: 13\r\n"
+                + "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n";
+        int port = startServer(tempDir, wsApp());
+        try (WsResponse response = handshake(port, headers)) {
+            assertEquals("HTTP/1.1 101 Switching Protocols", response.status);
+            assertEquals("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=", response.header("Sec-WebSocket-Accept"));
+        }
+    }
+
+    @Test
+    void handshake_alongside_http_and_sse(@TempDir Path tempDir) throws Exception {
+        String app = """
+                main() {
+                    var app = web.app()
+                    app.get("/hello") { return "Hello WS" }
+                    app.sse("/events") { sse.send("hello") }
+                    app.ws("/ws") { return "x" }
+                    app.listen(PORT)
+                }
+                """;
+        int port = startServer(tempDir, app);
+        String http = request(port, "GET /hello HTTP/1.1\r\nHost: x\r\n\r\n");
+        assertTrue(http.startsWith("HTTP/1.1 200 OK"), http);
+        assertTrue(http.contains("Hello WS"), http);
+        String sse = request(port, "GET /events HTTP/1.1\r\nHost: x\r\n"
+                + "Accept: text/event-stream\r\n\r\n");
+        assertTrue(sse.startsWith("HTTP/1.1 200 OK"), sse);
+        assertTrue(sse.contains("data: hello"), sse);
+        try (WsResponse ws = handshake(port, VALID_HEADERS)) {
+            assertEquals("HTTP/1.1 101 Switching Protocols", ws.status);
+            assertEquals("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=",
+                    ws.header("Sec-WebSocket-Accept"));
+        }
+    }
+}


### PR DESCRIPTION
PR3 implements the RFC 6455 WebSocket handshake on the JVM target. Stacked on PR #15 (PR2 SSE) which is itself stacked on PR #14 (PR1 persistent connection). Frame codec and idiomatic `ws.onMessage` API land in PR4/PR5.

## Wire-protocol validation

For every matched WS route the dispatcher validates the four RFC 6455 §4.1.1 preconditions before responding:

| Header | Required token (RFC 7230 list) |
| --- | --- |
| `Upgrade` | includes `websocket` (case-insensitive) |
| `Connection` | includes `Upgrade` (case-insensitive) |
| `Sec-WebSocket-Version` | `13` |
| `Sec-WebSocket-Key` | present, any non-null base64-value |

Header lookups go through the existing `WebRequest.headers` map (lower-cased keys, trimmed values) and a small `containsToken(value, expected)` helper that splits by `,` per RFC 7230 §3.2.2 and matches case-insensitively. A comma-separated `Connection: keep-alive, Upgrade` is accepted — the original substring-match prototype would have rejected this.

A request that fails validation gets a clean `HTTP/1.1 400 Bad Request` response and the socket is closed.

A successful request gets:

```
HTTP/1.1 101 Switching Protocols\r\n
Upgrade: websocket\r\n
Connection: Upgrade\r\n
Sec-WebSocket-Accept: <base64(sha1(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))>\r\n
\r\n
```

The `Sec-WebSocket-Accept` value is computed by `wsAccept(key)` using JDK `MessageDigest("SHA-1")` and `Base64.getEncoder().encodeToString`, matching RFC 6455 §4.2.2.

After the 101 the connection remains open and any client bytes are silently discarded until EOF or the 5-minute per-connection idle (`KEEPALIVE_IDLE_MS`, established in PR1). PR4 replaces the stub loop with the real frame codec.

## File-by-file

| File | Change |
| --- | --- |
| `kof-compiler/.../JvmWebRuntime.java` | New `wsAccept(String)` static helper. SHA-1 + Base64, no external crypto dependency. |
| `kof-compiler/.../JvmRuntime.java` | `kof_web_handle` branches on `RouteKind.WS` and dispatches into `kof_web_ws_handshake(req, client)`. Validates the four headers above via the parsed `WebRequest.headers` map and the new `containsToken` helper (handles comma-separated `Connection: keep-alive, Upgrade` correctly). Writes 101 or 400, then sits on the socket until client disconnects or the per-connection idle timer fires. |
| `kof-compiler/src/test/.../KofWebWsE2ETest.java` | **New file.** 8 E2E scenarios over a raw TCP socket: handshake with correct `Sec-WebSocket-Accept`, missing key, old version (`8`), missing upgrade, missing connection-upgrade, socket stays open, coexistence with HTTP and SSE on the same `WebApp`, **and** a regression for the comma-separated-token case the previous substring validator would have rejected. |

## Public API impact

None yet. `app.ws(path) { body }` still compiles into a WS route registration, but the trailing block does not yet produce `onMessage`-style bindings — that's PR5 (idiomatic WS API). For PR3 the route is registered but the user-visible body is still ignored at runtime; the connection is held open by the stub. A user who wants to use WS right now can write:

```kof
app.ws("/chat") { }
// or
app.ws("/chat", (_ws: KofRuntime$WsConnection) -> { })
```

…and rely on the handshake completing. Frame handling lands in PR4.

## Risks captured

- `Sec-WebSocket-Key` is treated as opaque base64; we don't decode it. RFC 6455 doesn't require decoding — the server only echoes a value computed from it — so this is fine and simpler than introducing a parser.
- No frame parser yet. Frames received after the 101 are silently discarded. PR4 handles this end-to-end.

## Verification

```
mvn -pl kof-compiler -am test -Dtest='KofWebE2ETest,KofWebTlsTest,KofWebSseE2ETest,KofWebWsE2ETest'
→ Tests run: 30, Failures: 0, Errors: 0, Skipped: 0
→ BUILD SUCCESS

mvn -pl kof-compiler -am test (full suite)
→ 652 tests, 197 pre-existing Native backend failures on this host (unchanged), JVM and TLS green.
```

## Out of scope (subsequent PRs)

PR4 — WebSocket frame codec (TEXT/BINARY/CLOSE/PING/PONG, masking, payload lengths 7-/16-/64-bit).
PR5 — Idiomatic WS API (`onOpen`/`onMessage`/`onClose`/`send`/`close`), reusing the same `SemanticAnalyzer` sugar pattern from PR2.
PR6 — Hardening (limits, idle cap, malformed frames, JS/Native stubs).
PR7 — Doc sync.