### PR TITLE
feat(web): RFC 6455 WebSocket frame codec + lifecycle

### DIFF
--- a/kof-compiler/src/main/java/dev/kof/compiler/CompilerDriver.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/CompilerDriver.java
@@ -3458,7 +3458,7 @@ private Target target = Target.JVM;
                 } else if (mc.receiver() instanceof IdentifierExpr rid && !isLocalVarName(rid.name(), locals)
                             && KofWeb.isWebNamespace(rid.name())) {
                     if ("app".equals(mc.methodName()) && mc.arguments().isEmpty()) {
-                        if (target != Target.JVM) {
+                        if (target != Target.JVM && target != Target.ANDROID) {
                             if (currentDiagnostics != null) {
                                 currentDiagnostics.error(mc.position() != null ? mc.position().file() : "",
                                         mc.position() != null ? mc.position().line() : 0,
@@ -3624,11 +3624,18 @@ private Target target = Target.JVM;
                         for (ExpressionNode arg : mc.arguments()) webArgTypes.add(inferExprType(arg, locals));
                         KofWeb.WebCall webCall = KofWeb.instanceMethod(mc.methodName(), webArgTypes);
                         if (webCall != null) {
-                            if (target != Target.JVM) {
-                                String webCode = "kof_web_listen_secure".equals(webCall.function()) ? "WEB002" : "WEB001";
-                                String webMsg = "kof_web_listen_secure".equals(webCall.function())
-                                        ? "web TLS: not available on the " + target + " target yet (WEB002)"
-                                        : "web: not available on the " + target + " target yet (WEB001)";
+                            if (target != Target.JVM && target != Target.ANDROID) {
+                                String webCode = KofWeb.gapCode(webCall.function());
+                                String webMsg = switch (webCode) {
+                                    case "WEB002" -> "web TLS: not available on the " + target
+                                            + " target yet (WEB002)";
+                                    case "WEB003" -> "web SSE: not available on the " + target
+                                            + " target yet (WEB003)";
+                                    case "WEB004" -> "web WebSocket: not available on the " + target
+                                            + " target yet (WEB004)";
+                                    default -> "web: not available on the " + target
+                                            + " target yet (WEB001)";
+                                };
                                 if (currentDiagnostics != null) {
                                     currentDiagnostics.error(mc.position() != null ? mc.position().file() : "",
                                             mc.position() != null ? mc.position().line() : 0,
@@ -3637,18 +3644,16 @@ private Target target = Target.JVM;
                                 }
                                 yield localIdx;
                             }
-                            if (KofWeb.isRouteMethod(mc.methodName())) {
-                                ops.add(new KofLoadLiteral(BuiltinTypes.STRING, mc.methodName().toUpperCase()));
-                            }
-                            for (ExpressionNode arg : mc.arguments()) {
-                                localIdx = emitExpression(arg, ops, owner, localIdx, locals);
-                            }
                             List<Type> webParams = new ArrayList<>();
                             webParams.add(BuiltinTypes.STRING);
-                            if (KofWeb.isRouteMethod(mc.methodName())) {
+                            if (KofWeb.isRouteMethod(mc.methodName()) && !"ws".equals(mc.methodName())) {
+                                ops.add(new KofLoadLiteral(BuiltinTypes.STRING, mc.methodName().toUpperCase()));
                                 webParams.add(BuiltinTypes.STRING);
                             }
-                            webParams.addAll(webCall.parameterTypes());
+                            for (ExpressionNode arg : mc.arguments()) {
+                                webParams.add(inferExprType(arg, locals));
+                                localIdx = emitExpression(arg, ops, owner, localIdx, locals);
+                            }
                             ops.add(new KofCall(KofWeb.APP, webCall.function(), webParams,
                                     webCall.returnType(), KofCallKind.FUNCTION));
                         }

--- a/kof-compiler/src/main/java/dev/kof/compiler/JvmRuntime.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/JvmRuntime.java
@@ -424,8 +424,8 @@ static boolean hasRuntimeFn(String methodName) {
                         try {
                             java.net.Socket client = app.serverSocket.accept();
                             // 15s default protects HTTP `readRequest` against
-                            // client half-open sockets. SSE/WS override this
-                            // higher inside `kof_web_keep_alive`.
+                            // client half-open sockets. WS raises this after
+                            // the handshake.
                             client.setSoTimeout(15000);
                             Thread.startVirtualThread(() -> kof_web_handle(app, client));
                         } catch (java.io.IOException e) {
@@ -518,8 +518,8 @@ static boolean hasRuntimeFn(String methodName) {
                             handler.join();
                             return;
                         }
-                        if (result.kind != RouteKind.HTTP) {
-                            kof_web_keep_alive(client);
+                        if (result.kind == RouteKind.WS) {
+                            kof_web_ws_handshake(req, client);
                             return;
                         }
                         client.getOutputStream().write(result.response.getBytes(java.nio.charset.StandardCharsets.UTF_8));
@@ -529,25 +529,61 @@ static boolean hasRuntimeFn(String methodName) {
                     }
                 }
 
-                // Idle timeout for persistent connections (SSE/WS in PR2/PR3).
-                // Without this, a client that opens the socket and never sends
-                // data would pin a virtual thread indefinitely. PR6 may move
-                // this to a configurable `web.configure(...)` knob.
+                // Idle timeout for the WS handshake stub. PR4 replaces the read
+                // loop with a frame codec and per-connection timeout handling.
                 private static final int KEEPALIVE_IDLE_MS = 300_000;
 
-                private static void kof_web_keep_alive(java.net.Socket client) throws java.io.IOException {
-                    client.setSoTimeout(KEEPALIVE_IDLE_MS);
-                    byte[] buffer = new byte[8192];
-                    try {
-                        while (client.getInputStream().read(buffer) != -1) {
-                            // PR1: no SSE/WS protocol yet; PR2/PR3 replace this with real loops.
-                            // Until then, any bytes from the client are discarded.
-                        }
-                    } catch (java.net.SocketTimeoutException idle) {
-                        // Idle socket — close cleanly. PR2 will replace this body with
-                        // real SSE/WS loops that respect the same per-read budget.
+                private static void kof_web_ws_handshake(WebRequest req, java.net.Socket client)
+                        throws java.io.IOException {
+                    String upgradeVal = req.headers.get("upgrade");
+                    String connectionVal = req.headers.get("connection");
+                    String version = req.headers.get("sec-websocket-version");
+                    String key = req.headers.get("sec-websocket-key");
+
+                    boolean hasUpgrade = containsToken(upgradeVal, "websocket");
+                    boolean hasConnection = containsToken(connectionVal, "upgrade");
+                    boolean valid = hasUpgrade
+                            && hasConnection
+                            && "13".equals(version)
+                            && key != null;
+
+                    if (!valid) {
+                        java.io.OutputStream out = client.getOutputStream();
+                        out.write("HTTP/1.1 400 Bad Request\\r\\n\\r\\n"
+                                .getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                        out.flush();
+                        return;
                     }
+
+                    String accept = wsAccept(key);
+                    java.io.OutputStream out = client.getOutputStream();
+                    out.write(("HTTP/1.1 101 Switching Protocols\\r\\n"
+                            + "Upgrade: websocket\\r\\n"
+                            + "Connection: Upgrade\\r\\n"
+                            + "Sec-WebSocket-Accept: " + accept + "\\r\\n"
+                            + "\\r\\n").getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                    out.flush();
+
+                    // Stub frame loop (PR4 substitui). Lê bytes até EOF ou timeout.
+                    client.setSoTimeout(KEEPALIVE_IDLE_MS);
+                    byte[] buf = new byte[8192];
+                    try {
+                        while (client.getInputStream().read(buf) != -1) { /* discard */ }
+                    } catch (java.net.SocketTimeoutException ignored) { /* idle */ }
                 }
+
+                    // Splits a comma-separated header value (RFC 7230 §3.2.2) into
+                    // trimmed tokens, returning true when any token equals the
+                    // expected name case-insensitively. Null/empty header -> false.
+                    // Used by WS handshake to validate Upgrade/Connection tokens
+                    // even when the same line carries unrelated tokens.
+                    private static boolean containsToken(String headerValue, String expected) {
+                        if (headerValue == null) return false;
+                        for (String token : headerValue.split(",")) {
+                            if (token.trim().equalsIgnoreCase(expected)) return true;
+                        }
+                        return false;
+                    }
 
                 private static WebDispatchResult kof_web_dispatch(WebApp app, WebRequest req) {
                     KOF_WEB_REQUEST.set(req);

--- a/kof-compiler/src/main/java/dev/kof/compiler/JvmRuntime.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/JvmRuntime.java
@@ -153,6 +153,8 @@ static boolean hasRuntimeFn(String methodName) {
             case "kof_io_dir_list" -> "(Ljava/lang/String;)Ljava/util/ArrayList;";
             case "kof_web_app_new" -> "()Ljava/lang/String;";
             case "kof_web_route" -> "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V";
+            case "kof_web_sse_route" -> "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V";
+            case "kof_web_ws_route" -> "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V";
             case "kof_web_use" -> "(Ljava/lang/String;Ljava/lang/Object;)V";
             case "kof_web_listen" -> "(Ljava/lang/String;I)V";
             case "kof_web_listen_secure" -> "(Ljava/lang/String;I)V";
@@ -326,7 +328,8 @@ static boolean hasRuntimeFn(String methodName) {
             case "kof_http_status", "kof_mq_queue_size" -> "I";
             case "kof_mq_queue" -> "Ljava/lang/String;";
             case "kof_mq_pop" -> "Ljava/lang/Object;";
-            case "kof_http_timeout_set", "kof_mq_publish", "kof_mq_subscribe", "kof_mq_unsubscribe",
+            case "kof_web_sse_route", "kof_web_ws_route", "kof_http_timeout_set",
+                    "kof_mq_publish", "kof_mq_subscribe", "kof_mq_unsubscribe",
                     "kof_mq_push", "kof_time_sleep", "kof_time_cancel", "kof_scheduler_cancel" -> "V";
             case "kof_time_now" -> "J";
             case "kof_time_interval" -> "Ljava/lang/String;";
@@ -420,6 +423,9 @@ static boolean hasRuntimeFn(String methodName) {
                     while (app.running) {
                         try {
                             java.net.Socket client = app.serverSocket.accept();
+                            // 15s default protects HTTP `readRequest` against
+                            // client half-open sockets. SSE/WS override this
+                            // higher inside `kof_web_keep_alive`.
                             client.setSoTimeout(15000);
                             Thread.startVirtualThread(() -> kof_web_handle(app, client));
                         } catch (java.io.IOException e) {
@@ -483,15 +489,39 @@ static boolean hasRuntimeFn(String methodName) {
                 private static void kof_web_handle(WebApp app, java.net.Socket client) {
                     try (client) {
                         WebRequest req = readRequest(client.getInputStream());
-                        String response = kof_web_dispatch(app, req);
-                        client.getOutputStream().write(response.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                        WebDispatchResult result = kof_web_dispatch(app, req);
+                        if (result.kind != RouteKind.HTTP) {
+                            kof_web_keep_alive(client);
+                            return;
+                        }
+                        client.getOutputStream().write(result.response.getBytes(java.nio.charset.StandardCharsets.UTF_8));
                         client.getOutputStream().flush();
                     } catch (Exception e) {
                         System.err.println("kof web connection error: " + e.getMessage());
                     }
                 }
 
-                private static String kof_web_dispatch(WebApp app, WebRequest req) {
+                // Idle timeout for persistent connections (SSE/WS in PR2/PR3).
+                // Without this, a client that opens the socket and never sends
+                // data would pin a virtual thread indefinitely. PR6 may move
+                // this to a configurable `web.configure(...)` knob.
+                private static final int KEEPALIVE_IDLE_MS = 300_000;
+
+                private static void kof_web_keep_alive(java.net.Socket client) throws java.io.IOException {
+                    client.setSoTimeout(KEEPALIVE_IDLE_MS);
+                    byte[] buffer = new byte[8192];
+                    try {
+                        while (client.getInputStream().read(buffer) != -1) {
+                            // PR1: no SSE/WS protocol yet; PR2/PR3 replace this with real loops.
+                            // Until then, any bytes from the client are discarded.
+                        }
+                    } catch (java.net.SocketTimeoutException idle) {
+                        // Idle socket — close cleanly. PR2 will replace this body with
+                        // real SSE/WS loops that respect the same per-read budget.
+                    }
+                }
+
+                private static WebDispatchResult kof_web_dispatch(WebApp app, WebRequest req) {
                     KOF_WEB_REQUEST.set(req);
                     KOF_WEB_STATUS.remove();
                     KOF_WEB_HEADERS.get().clear();
@@ -506,11 +536,11 @@ static boolean hasRuntimeFn(String methodName) {
                                 String resp = kof_web_build(code, text, String.valueOf(result));
                                 KOF_WEB_STATUS.remove();
                                 KOF_WEB_HEADERS.get().clear();
-                                return resp;
+                                return new WebDispatchResult(RouteKind.HTTP, resp);
                             }
                         }
                         for (WebRoute route : app.routes) {
-                            if (!route.method.equals(req.method)) continue;
+                            if (route.kind == RouteKind.HTTP && !route.method.equals(req.method)) continue;
                             String[] pathSegs = req.path.split("/");
                             if (pathSegs.length != route.segments.length) continue;
                             boolean match = true;
@@ -525,13 +555,19 @@ static boolean hasRuntimeFn(String methodName) {
                             }
                             if (!match) continue;
                             req.params.putAll(params);
+                            if (route.kind != RouteKind.HTTP) {
+                                KOF_WEB_STATUS.remove();
+                                KOF_WEB_HEADERS.get().clear();
+                                return new WebDispatchResult(route.kind, null);
+                            }
                             KOF_WEB_STATUS.remove();
                             KOF_WEB_HEADERS.get().clear();
                             Object result = kof_web_invoke(route.handler, req);
                             if (result == null) {
                                 KOF_WEB_STATUS.remove();
                                 KOF_WEB_HEADERS.get().clear();
-                                return kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}");
+                                return new WebDispatchResult(RouteKind.HTTP,
+                                        kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}"));
                             }
                             Integer st2 = KOF_WEB_STATUS.get();
                             int code2 = st2 != null ? st2 : 200;
@@ -539,15 +575,17 @@ static boolean hasRuntimeFn(String methodName) {
                             String resp2 = kof_web_build(code2, text2, String.valueOf(result));
                             KOF_WEB_STATUS.remove();
                             KOF_WEB_HEADERS.get().clear();
-                            return resp2;
+                            return new WebDispatchResult(RouteKind.HTTP, resp2);
                         }
-                        return kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}");
+                        return new WebDispatchResult(RouteKind.HTTP,
+                                kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}"));
                     } catch (Exception e) {
                         String msg = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
                         KOF_WEB_STATUS.remove();
                         KOF_WEB_HEADERS.get().clear();
-                        return kof_web_build(500, "Internal Server Error",
-                                "{\\"error\\": \\"handler error: " + msg + "\\"}");
+                        return new WebDispatchResult(RouteKind.HTTP,
+                                kof_web_build(500, "Internal Server Error",
+                                        "{\\"error\\": \\"handler error: " + msg + "\\"}"));
                     } finally {
                         KOF_WEB_REQUEST.remove();
                         KOF_LOG_REQUEST_ID.remove();

--- a/kof-compiler/src/main/java/dev/kof/compiler/JvmRuntime.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/JvmRuntime.java
@@ -564,26 +564,93 @@ static boolean hasRuntimeFn(String methodName) {
                             + "\\r\\n").getBytes(java.nio.charset.StandardCharsets.UTF_8));
                     out.flush();
 
-                    // Stub frame loop (PR4 substitui). Lê bytes até EOF ou timeout.
+                    // Frame loop (PR4): handles RFC 6455 frame codec.
+                    // PING -> PONG; CLOSE -> ack CLOSE; oversize -> CLOSE 1009.
+                    // TEXT/BINARY frames are discarded for now (PR5 wires the
+                    // Kof handler).
                     client.setSoTimeout(KEEPALIVE_IDLE_MS);
-                    byte[] buf = new byte[8192];
                     try {
-                        while (client.getInputStream().read(buf) != -1) { /* discard */ }
-                    } catch (java.net.SocketTimeoutException ignored) { /* idle */ }
+                        frameLoop: while (true) {
+                            // 1) Read until we have at least 2 bytes for the header
+                            int headerBytes = 0;
+                            byte[] headerBuf = new byte[2];
+                            while (headerBytes < 2) {
+                                int n = client.getInputStream().read(headerBuf, headerBytes, 2 - headerBytes);
+                                if (n < 0) break frameLoop;
+                                headerBytes += n;
+                            }
+                            boolean fin = (headerBuf[0] & 0x80) != 0;
+                            int op = headerBuf[0] & 0x0F;
+                            boolean masked = (headerBuf[1] & 0x80) != 0;
+                            long plen = headerBuf[1] & 0x7F;
+                            // 2) Extended length
+                            if (plen == 126) {
+                                byte[] ext = new byte[2];
+                                readFully(client.getInputStream(), ext);
+                                plen = ((long)(ext[0] & 0xFF) << 8) | (ext[1] & 0xFF);
+                            } else if (plen == 127) {
+                                byte[] ext = new byte[8];
+                                readFully(client.getInputStream(), ext);
+                                plen = 0;
+                                for (int i = 0; i < 8; i++) plen = (plen << 8) | (ext[i] & 0xFF);
+                            }
+                            WsConnection conn = new WsConnection(client.getOutputStream());
+                            if (!fin) {
+                                conn.close(WsFrame.CLOSE_UNSUPPORTED, "fragmented frames not supported");
+                                break frameLoop;
+                            }
+                            // 3) Mask key (must be present on client->server)
+                            byte[] mask = new byte[4];
+                            if (masked) {
+                                readFully(client.getInputStream(), mask);
+                            } else {
+                                conn.close(WsFrame.CLOSE_PROTOCOL_ERROR, "client frame must be masked");
+                                break frameLoop;
+                            }
+                            // 4) Payload (with size cap)
+                            if (plen > WsFrame.MAX_FRAME_BYTES) {
+                                conn.close(WsFrame.CLOSE_TOO_BIG, "frame too large");
+                                break frameLoop;
+                            }
+                            byte[] payload = new byte[(int) plen];
+                            if (plen > 0) {
+                                readFully(client.getInputStream(), payload);
+                                if (masked) for (int i = 0; i < payload.length; i++) payload[i] ^= mask[i % 4];
+                            }
+                            // 5) React
+                            if (op == 0x9 /* PING */) { conn.pong(payload); }
+                            else if (op == 0xA /* PONG */) { /* ignore */ }
+                            else if (op == 0x8 /* CLOSE */) { conn.close(1000, ""); break frameLoop; }
+                            // TEXT/BINARY/CONT: discard for now (PR5)
+                        }
+                    } catch (java.net.SocketTimeoutException idle) {
+                        // graceful close after KEEPALIVE_IDLE_MS
+                    } catch (java.io.IOException eof) {
+                        // client closed
+                    }
                 }
 
-                    // Splits a comma-separated header value (RFC 7230 §3.2.2) into
-                    // trimmed tokens, returning true when any token equals the
-                    // expected name case-insensitively. Null/empty header -> false.
-                    // Used by WS handshake to validate Upgrade/Connection tokens
-                    // even when the same line carries unrelated tokens.
-                    private static boolean containsToken(String headerValue, String expected) {
-                        if (headerValue == null) return false;
-                        for (String token : headerValue.split(",")) {
-                            if (token.trim().equalsIgnoreCase(expected)) return true;
-                        }
-                        return false;
+                private static void readFully(java.io.InputStream in, byte[] buf) throws java.io.IOException {
+                    int off = 0;
+                    while (off < buf.length) {
+                        int n = in.read(buf, off, buf.length - off);
+                        if (n < 0) throw new java.io.IOException("EOF reading " + buf.length + " bytes (got " + off + ")");
+                        off += n;
                     }
+                }
+
+                // Splits a comma-separated header value (RFC 7230 §3.2.2) into
+                // trimmed tokens, returning true when any token equals the
+                // expected name case-insensitively. Null/empty header -> false.
+                // Used by WS handshake to validate Upgrade/Connection tokens
+                // even when the same line carries unrelated tokens.
+                private static boolean containsToken(String headerValue, String expected) {
+                    if (headerValue == null) return false;
+                    for (String token : headerValue.split(",")) {
+                        if (token.trim().equalsIgnoreCase(expected)) return true;
+                    }
+                    return false;
+                }
 
                 private static WebDispatchResult kof_web_dispatch(WebApp app, WebRequest req) {
                     KOF_WEB_REQUEST.set(req);

--- a/kof-compiler/src/main/java/dev/kof/compiler/JvmRuntime.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/JvmRuntime.java
@@ -490,6 +490,34 @@ static boolean hasRuntimeFn(String methodName) {
                     try (client) {
                         WebRequest req = readRequest(client.getInputStream());
                         WebDispatchResult result = kof_web_dispatch(app, req);
+                        if (result.kind == RouteKind.SSE) {
+                            java.io.OutputStream out = client.getOutputStream();
+                            out.write(("HTTP/1.1 200 OK\\r\\n"
+                                    + "Content-Type: text/event-stream\\r\\n"
+                                    + "Cache-Control: no-cache\\r\\n"
+                                    + "Connection: keep-alive\\r\\n"
+                                    + "X-Accel-Buffering: no\\r\\n"
+                                    + "\\r\\n").getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                            out.flush();
+                            SseConnection sse = new SseConnection(out);
+                            Thread handler = Thread.startVirtualThread(() -> {
+                                try {
+                                    KOF_WEB_REQUEST.set(req);
+                                    try {
+                                        kof_web_invoke(result.route.handler, sse);
+                                    } finally {
+                                        KOF_WEB_REQUEST.remove();
+                                    }
+                                } catch (Exception e) {
+                                    System.err.println("kof web sse handler error: "
+                                            + e.getMessage());
+                                } finally {
+                                    sse.close();
+                                }
+                            });
+                            handler.join();
+                            return;
+                        }
                         if (result.kind != RouteKind.HTTP) {
                             kof_web_keep_alive(client);
                             return;
@@ -536,7 +564,7 @@ static boolean hasRuntimeFn(String methodName) {
                                 String resp = kof_web_build(code, text, String.valueOf(result));
                                 KOF_WEB_STATUS.remove();
                                 KOF_WEB_HEADERS.get().clear();
-                                return new WebDispatchResult(RouteKind.HTTP, resp);
+                                return new WebDispatchResult(RouteKind.HTTP, resp, null);
                             }
                         }
                         for (WebRoute route : app.routes) {
@@ -558,7 +586,7 @@ static boolean hasRuntimeFn(String methodName) {
                             if (route.kind != RouteKind.HTTP) {
                                 KOF_WEB_STATUS.remove();
                                 KOF_WEB_HEADERS.get().clear();
-                                return new WebDispatchResult(route.kind, null);
+                                return new WebDispatchResult(route.kind, null, route);
                             }
                             KOF_WEB_STATUS.remove();
                             KOF_WEB_HEADERS.get().clear();
@@ -567,7 +595,7 @@ static boolean hasRuntimeFn(String methodName) {
                                 KOF_WEB_STATUS.remove();
                                 KOF_WEB_HEADERS.get().clear();
                                 return new WebDispatchResult(RouteKind.HTTP,
-                                        kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}"));
+                                        kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}"), null);
                             }
                             Integer st2 = KOF_WEB_STATUS.get();
                             int code2 = st2 != null ? st2 : 200;
@@ -575,17 +603,17 @@ static boolean hasRuntimeFn(String methodName) {
                             String resp2 = kof_web_build(code2, text2, String.valueOf(result));
                             KOF_WEB_STATUS.remove();
                             KOF_WEB_HEADERS.get().clear();
-                            return new WebDispatchResult(RouteKind.HTTP, resp2);
+                            return new WebDispatchResult(RouteKind.HTTP, resp2, null);
                         }
                         return new WebDispatchResult(RouteKind.HTTP,
-                                kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}"));
+                                kof_web_build(404, "Not Found", "{\\"error\\": \\"not found\\"}"), null);
                     } catch (Exception e) {
                         String msg = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
                         KOF_WEB_STATUS.remove();
                         KOF_WEB_HEADERS.get().clear();
                         return new WebDispatchResult(RouteKind.HTTP,
                                 kof_web_build(500, "Internal Server Error",
-                                        "{\\"error\\": \\"handler error: " + msg + "\\"}"));
+                                        "{\\"error\\": \\"handler error: " + msg + "\\"}"), null);
                     } finally {
                         KOF_WEB_REQUEST.remove();
                         KOF_LOG_REQUEST_ID.remove();
@@ -603,6 +631,11 @@ static boolean hasRuntimeFn(String methodName) {
                                         String.class, String.class)
                                 .invoke(target, req.method, req.path, req.body, req.query, req.rawHeaders);
                     }
+                }
+
+                private static Object kof_web_invoke(Object target, SseConnection sse) throws Exception {
+                    return target.getClass().getMethod("invoke", SseConnection.class)
+                            .invoke(target, sse);
                 }
 
                 private static String kof_web_build(int status, String statusText, String body) {

--- a/kof-compiler/src/main/java/dev/kof/compiler/JvmWebRuntime.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/JvmWebRuntime.java
@@ -58,7 +58,7 @@ final class JvmWebRuntime {
 
                 public enum RouteKind { HTTP, SSE, WS }
 
-                record WebDispatchResult(RouteKind kind, String response) {}
+                record WebDispatchResult(RouteKind kind, String response, WebRoute route) {}
 
                 public static final class WebRoute {
                     final String method;
@@ -124,6 +124,65 @@ final class JvmWebRuntime {
 
                     String header(String name) {
                         return headers.get(name.toLowerCase());
+                    }
+                }
+
+                public static final class SseConnection {
+                    private final java.io.OutputStream out;
+                    private final byte[] nl = "\\n".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                    private final java.util.concurrent.atomic.AtomicBoolean open =
+                            new java.util.concurrent.atomic.AtomicBoolean(true);
+                    private final java.util.concurrent.locks.ReentrantLock writeLock =
+                            new java.util.concurrent.locks.ReentrantLock();
+
+                    SseConnection(java.io.OutputStream out) {
+                        this.out = out;
+                    }
+
+                    public void send(String data) {
+                        writeData(data);
+                    }
+
+                    public void event(String name, String data) {
+                        writeFrame("event: " + name + "\\n");
+                        writeData(data);
+                    }
+
+                    public void close() {
+                        if (open.compareAndSet(true, false)) {
+                            writeLock.lock();
+                            try {
+                                out.flush();
+                                out.close();
+                            } catch (java.io.IOException ignored) {
+                            } finally {
+                                writeLock.unlock();
+                            }
+                        }
+                    }
+
+                    public boolean isOpen() {
+                        return open.get();
+                    }
+
+                    private void writeData(String data) {
+                        for (String line : data.split("\\n", -1)) {
+                            writeFrame("data: " + line + "\\n");
+                        }
+                        writeFrame("\\n");
+                    }
+
+                    private void writeFrame(String frame) {
+                        if (!open.get()) return;
+                        writeLock.lock();
+                        try {
+                            out.write(frame.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                            out.flush();
+                        } catch (java.io.IOException e) {
+                            open.set(false);
+                        } finally {
+                            writeLock.unlock();
+                        }
                     }
                 }
 

--- a/kof-compiler/src/main/java/dev/kof/compiler/JvmWebRuntime.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/JvmWebRuntime.java
@@ -197,6 +197,146 @@ final class JvmWebRuntime {
                     }
                 }
 
+                public static final class WsFrame {
+                    public final boolean fin;
+                    public final int opcode;        // 0x1=TEXT, 0x2=BINARY, 0x8=CLOSE, 0x9=PING, 0xA=PONG, 0x0=continuation
+                    public final byte[] payload;
+
+                    WsFrame(boolean fin, int opcode, byte[] payload) {
+                        this.fin = fin;
+                        this.opcode = opcode;
+                        this.payload = payload;
+                    }
+
+                    /**
+                     * Encode a frame WITHOUT masking (server -> client per RFC 6455).
+                     * FIN=1 by default; use overload for FIN=0.
+                     */
+                    public static byte[] encode(int opcode, byte[] payload, boolean fin) {
+                        // Header byte 1: FIN(1) RSV(3) OPCODE(4)
+                        int b1 = (fin ? 0x80 : 0x00) | (opcode & 0x0F);
+                        // Header byte 2: MASK(1) + LEN(7)
+                        long len = payload.length;
+                        byte[] header;
+                        int headerLen;
+                        if (len <= 125) {
+                            header = new byte[2];
+                            header[1] = (byte) len;       // MASK=0
+                            headerLen = 2;
+                        } else if (len <= 0xFFFF) {
+                            header = new byte[4];
+                            header[1] = (byte) 126;       // MASK=0
+                            header[2] = (byte) ((len >> 8) & 0xFF);
+                            header[3] = (byte) (len & 0xFF);
+                            headerLen = 4;
+                        } else {
+                            header = new byte[10];
+                            header[1] = (byte) 127;       // MASK=0
+                            for (int i = 0; i < 8; i++) {
+                                header[2 + i] = (byte) ((len >> (56 - i * 8)) & 0xFF);
+                            }
+                            headerLen = 10;
+                        }
+                        header[0] = (byte) b1;
+                        byte[] out = new byte[headerLen + (int) len];
+                        System.arraycopy(header, 0, out, 0, headerLen);
+                        System.arraycopy(payload, 0, out, headerLen, (int) len);
+                        return out;
+                    }
+
+                    /**
+                     * Decode a server-received (client -> server) frame. Payload is UNMASKED in
+                     * the returned WsFrame. RFC 6455 requires client->server masking; we reject
+                     * (close 1002) frames missing the mask bit.
+                     */
+                    public static WsFrame decodeClient(byte[] buf) throws java.io.IOException {
+                        if (buf.length < 2) throw new java.io.IOException("frame too short: " + buf.length);
+                        boolean fin = (buf[0] & 0x80) != 0;
+                        int opcode = buf[0] & 0x0F;
+                        boolean masked = (buf[1] & 0x80) != 0;
+                        if (!masked) throw new java.io.IOException("client frame must be masked (RFC 6455 §5.1)");
+                        long len = buf[1] & 0x7F;
+                        int idx = 2;
+                        if (len == 126) {
+                            if (buf.length < 4) throw new java.io.IOException("frame truncated on extended length");
+                            len = ((long)(buf[2] & 0xFF) << 8) | (buf[3] & 0xFF);
+                            idx = 4;
+                        } else if (len == 127) {
+                            if (buf.length < 10) throw new java.io.IOException("frame truncated on extended length");
+                            len = 0;
+                            for (int i = 0; i < 8; i++) {
+                                len = (len << 8) | (buf[2 + i] & 0xFF);
+                            }
+                            idx = 10;
+                        }
+                        if (len > MAX_FRAME_BYTES) {
+                            throw new java.io.IOException("frame too large: " + len + " > " + MAX_FRAME_BYTES);
+                        }
+                        if (buf.length < idx + 4 + len) throw new java.io.IOException("frame truncated (payload)");
+                        byte[] mask = new byte[4];
+                        System.arraycopy(buf, idx, mask, 0, 4);
+                        idx += 4;
+                        byte[] payload = new byte[(int) len];
+                        for (long i = 0; i < len; i++) {
+                            payload[(int) i] = (byte) (buf[idx + (int) i] ^ mask[(int) (i % 4)]);
+                        }
+                        return new WsFrame(fin, opcode, payload);
+                    }
+
+                    public static final long MAX_FRAME_BYTES = 1L << 20;        // 1 MiB
+                    public static final long MAX_MESSAGE_BYTES = 8L << 20;     // 8 MiB
+                    public static final int CLOSE_TOO_BIG = 1009;
+                    public static final int CLOSE_PROTOCOL_ERROR = 1002;
+                    public static final int CLOSE_UNSUPPORTED = 1003;
+                }
+
+                public static final class WsConnection {
+                    private final java.io.OutputStream out;
+                    private final java.util.concurrent.locks.ReentrantLock writeLock =
+                            new java.util.concurrent.locks.ReentrantLock();
+
+                    WsConnection(java.io.OutputStream out) {
+                        this.out = out;
+                    }
+
+                    public void sendText(String s) {
+                        send(WsFrame.encode(0x1, s.getBytes(java.nio.charset.StandardCharsets.UTF_8), true));
+                    }
+                    public void sendBinary(byte[] payload) {
+                        send(WsFrame.encode(0x2, payload, true));
+                    }
+                    public void ping(byte[] payload) {
+                        if (payload.length > 125) throw new IllegalArgumentException("ping payload > 125");
+                        send(WsFrame.encode(0x9, payload, true));
+                    }
+                    public void pong(byte[] payload) {
+                        if (payload.length > 125) throw new IllegalArgumentException("pong payload > 125");
+                        send(WsFrame.encode(0xA, payload, true));
+                    }
+                    public void close(int code, String reason) {
+                        byte[] body = new byte[2 + (reason == null ? 0 : reason.length())];
+                        body[0] = (byte) ((code >> 8) & 0xFF);
+                        body[1] = (byte) (code & 0xFF);
+                        if (reason != null) {
+                            byte[] rb = reason.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                            System.arraycopy(rb, 0, body, 2, rb.length);
+                        }
+                        send(WsFrame.encode(0x8, body, true));
+                    }
+
+                    private void send(byte[] frame) {
+                        writeLock.lock();
+                        try {
+                            out.write(frame);
+                            out.flush();
+                        } catch (java.io.IOException e) {
+                            // close silently
+                        } finally {
+                            writeLock.unlock();
+                        }
+                    }
+                }
+
                 public static final class WebApp {
                     final String id;
                     final java.util.List<WebRoute> routes = new java.util.ArrayList<>();

--- a/kof-compiler/src/main/java/dev/kof/compiler/JvmWebRuntime.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/JvmWebRuntime.java
@@ -56,13 +56,19 @@ final class JvmWebRuntime {
                     };
                 }
 
+                public enum RouteKind { HTTP, SSE, WS }
+
+                record WebDispatchResult(RouteKind kind, String response) {}
+
                 public static final class WebRoute {
                     final String method;
                     final String[] segments;
                     final boolean[] params;
                     final Object handler;
+                    final RouteKind kind;
 
-                    WebRoute(String method, String path, Object handler) {
+                    WebRoute(RouteKind kind, String method, String path, Object handler) {
+                        this.kind = kind;
                         this.method = method;
                         String[] raw = path.split("/");
                         this.segments = new String[raw.length];
@@ -148,9 +154,23 @@ final class JvmWebRuntime {
                 public static void kof_web_route(String appId, String method, String path, Object handler) {
                     if (handler == null) throw new IllegalArgumentException("route handler is null");
                     String m = method.toUpperCase();
-                    if ("WS".equals(m)) m = "GET";
-                    if ("SSE".equals(m)) m = "GET";
-                    kof_web_app(appId).routes.add(new WebRoute(m, path, handler));
+                    if ("SSE".equals(m) || "WS".equals(m)) {
+                        throw new IllegalArgumentException(
+                                "route method " + m + " requires kof_web_sse_route/kof_web_ws_route");
+                    }
+                    kof_web_app(appId).routes.add(new WebRoute(RouteKind.HTTP, m, path, handler));
+                }
+
+                public static void kof_web_sse_route(String appId, String method, String path, Object handler) {
+                    if (handler == null) throw new IllegalArgumentException("route handler is null");
+                    kof_web_app(appId).routes.add(
+                            new WebRoute(RouteKind.SSE, method.toUpperCase(), path, handler));
+                }
+
+                public static void kof_web_ws_route(String appId, String path, Object handler) {
+                    if (handler == null) throw new IllegalArgumentException("route handler is null");
+                    kof_web_app(appId).routes.add(
+                            new WebRoute(RouteKind.WS, "WS", path, handler));
                 }
 
                 public static void kof_web_use(String appId, Object handler) {

--- a/kof-compiler/src/main/java/dev/kof/compiler/JvmWebRuntime.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/JvmWebRuntime.java
@@ -56,6 +56,17 @@ final class JvmWebRuntime {
                     };
                 }
 
+                public static String wsAccept(String secWebSocketKey) {
+                    try {
+                        String concat = secWebSocketKey + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+                        java.security.MessageDigest sha1 = java.security.MessageDigest.getInstance("SHA-1");
+                        byte[] hash = sha1.digest(concat.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                        return java.util.Base64.getEncoder().encodeToString(hash);
+                    } catch (Exception e) {
+                        throw new RuntimeException("SHA-1 unavailable on JVM", e);
+                    }
+                }
+
                 public enum RouteKind { HTTP, SSE, WS }
 
                 record WebDispatchResult(RouteKind kind, String response, WebRoute route) {}

--- a/kof-compiler/src/main/java/dev/kof/compiler/KofWeb.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/KofWeb.java
@@ -25,6 +25,8 @@ final class KofWeb {
     private KofWeb() {}
 
     static final Type APP = new Type.ClassType("kof.web", "App", List.of());
+    static final Type SSE_CONNECTION =
+            new Type.ClassType("dev.kof.runtime", "KofRuntime$SseConnection", List.of());
 
     private static final Type STR = BuiltinTypes.STRING;
     private static final Type INT = Type.PrimitiveType.INT;
@@ -36,6 +38,25 @@ final class KofWeb {
 
     static boolean isAppType(Type t) {
         return APP.equals(t);
+    }
+
+    static boolean isSseConnectionType(Type t) {
+        return SSE_CONNECTION.equals(t);
+    }
+
+    /** Methods available on the synthetic {@code sse} handler parameter. */
+    static WebCall sseConnectionMethod(String name, List<Type> argTypes) {
+        return switch (name) {
+            case "send" -> argTypes.size() == 1
+                    ? new WebCall(name, VOID, argTypes) : null;
+            case "event" -> argTypes.size() == 2
+                    ? new WebCall(name, VOID, argTypes) : null;
+            case "close" -> argTypes.isEmpty()
+                    ? new WebCall(name, VOID, List.of()) : null;
+            case "isOpen" -> argTypes.isEmpty()
+                    ? new WebCall(name, Type.PrimitiveType.BOOL, List.of()) : null;
+            default -> null;
+        };
     }
 
     static boolean isWebNamespace(String name) {

--- a/kof-compiler/src/main/java/dev/kof/compiler/KofWeb.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/KofWeb.java
@@ -68,6 +68,12 @@ final class KofWeb {
     /** Instance methods on {@code kof.web.App} receivers. */
     static WebCall instanceMethod(String name, List<Type> argTypes) {
         if (ROUTE_METHODS.contains(name)) {
+            if ("sse".equals(name)) {
+                return instanceSseMethod(name, argTypes);
+            }
+            if ("ws".equals(name)) {
+                return instanceWsMethod(name, argTypes);
+            }
             if (argTypes.size() == 2) {
                 return new WebCall("kof_web_route", VOID,
                         List.of(STR, STR, STR, argTypes.get(1)));
@@ -91,6 +97,34 @@ final class KofWeb {
                     ? new WebCall("kof_web_close", VOID, List.of(STR))
                     : null;
             default -> null;
+        };
+    }
+
+
+    /** {@code app.sse(path, handler)} — route kind SSE, protocol comes later. */
+    static WebCall instanceSseMethod(String name, List<Type> argTypes) {
+        return "sse".equals(name) && argTypes.size() == 2
+                ? new WebCall("kof_web_sse_route", VOID,
+                        List.of(STR, STR, STR, argTypes.get(1)))
+                : null;
+    }
+
+
+    /** {@code app.ws(path, handler)} — route kind WS, protocol comes later. */
+    static WebCall instanceWsMethod(String name, List<Type> argTypes) {
+        return "ws".equals(name) && argTypes.size() == 2
+                ? new WebCall("kof_web_ws_route", VOID,
+                        List.of(STR, STR, argTypes.get(1)))
+                : null;
+    }
+
+
+    static String gapCode(String function) {
+        return switch (function) {
+            case "kof_web_sse_route" -> "WEB003";
+            case "kof_web_ws_route" -> "WEB004";
+            case "kof_web_listen_secure" -> "WEB002";
+            default -> "WEB001";
         };
     }
 

--- a/kof-compiler/src/main/java/dev/kof/compiler/SemanticAnalyzer.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/SemanticAnalyzer.java
@@ -8,6 +8,9 @@ import java.util.Map;
 
 class SemanticAnalyzer {
 
+    private static final String SSE_CONNECTION_TYPE =
+            "dev.kof.runtime.KofRuntime$SseConnection";
+
     private SymbolTable currentScope;
     private CompilationUnitNode currentUnit;
 
@@ -1193,10 +1196,24 @@ class SemanticAnalyzer {
                         yield KofWeb.APP;
                     }
                     if (KofWeb.isAppType(recvType)) {
+                        if ("sse".equals(mc.methodName()) && mc.arguments().size() == 2
+                                && mc.arguments().get(1) instanceof LambdaExpr le
+                                && le.parameters().isEmpty()) {
+                            mc.arguments().set(1, new LambdaExpr(le.position(),
+                                    List.of(new FormalParameterNode(le.position(), List.of(),
+                                            SSE_CONNECTION_TYPE, "sse")), le.body()));
+                        }
                         List<Type> argTypes = new ArrayList<>();
                         for (ExpressionNode arg : mc.arguments()) argTypes.add(inferType(arg, scope));
                         KofWeb.WebCall webCall = KofWeb.instanceMethod(mc.methodName(), argTypes);
                         if (webCall != null) yield webCall.returnType();
+                        yield Type.UnknownType.UNKNOWN;
+                    }
+                    if (KofWeb.isSseConnectionType(recvType)) {
+                        List<Type> argTypes = new ArrayList<>();
+                        for (ExpressionNode arg : mc.arguments()) argTypes.add(inferType(arg, scope));
+                        KofWeb.WebCall sseCall = KofWeb.sseConnectionMethod(mc.methodName(), argTypes);
+                        if (sseCall != null) yield sseCall.returnType();
                         yield Type.UnknownType.UNKNOWN;
                     }
                     if (recvType instanceof Type.FunctionType ft) {

--- a/kof-compiler/src/test/java/dev/kof/compiler/KofWebE2ETest.java
+++ b/kof-compiler/src/test/java/dev/kof/compiler/KofWebE2ETest.java
@@ -221,4 +221,22 @@ class KofWebE2ETest {
         assertEquals("A", bodyOf(request(port, "GET /a HTTP/1.1\r\nHost: x\r\n\r\n")));
         assertEquals("B", bodyOf(request(port, "GET /b HTTP/1.1\r\nHost: x\r\n\r\n")));
     }
+
+    @Test
+    void sseAndWsGapOnNative(@TempDir Path tempDir) throws IOException {
+        Path source = tempDir.resolve("App.kf");
+        Files.writeString(source, """
+                main() {
+                    var app = web.app()
+                    app.sse("/events") { return "x" }
+                    app.ws("/chat") { return "x" }
+                }
+                """);
+        CompilationResult result = driver.compile(source, tempDir.resolve("out"), Target.NATIVE);
+        var diagnostics = result.diagnostics().getDiagnostics();
+        assertTrue(diagnostics.stream().anyMatch(d -> d.code().equals("WEB003")),
+                "Should have WEB003, got: " + diagnostics);
+        assertTrue(diagnostics.stream().anyMatch(d -> d.code().equals("WEB004")),
+                "Should have WEB004, got: " + diagnostics);
+    }
 }

--- a/kof-compiler/src/test/java/dev/kof/compiler/KofWebSseE2ETest.java
+++ b/kof-compiler/src/test/java/dev/kof/compiler/KofWebSseE2ETest.java
@@ -1,0 +1,290 @@
+package dev.kof.compiler;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * E2E tests for the Kof-native SSE stack ({@code app.sse(...)}).
+ */
+class KofWebSseE2ETest {
+
+    private static final String JAVA_BIN = Path.of(
+            System.getProperty("java.home"), "bin", "java").toString();
+
+    private Process serverProcess;
+
+    @AfterEach
+    void stopServer() {
+        if (serverProcess != null) {
+            serverProcess.destroy();
+            try {
+                serverProcess.waitFor(5, TimeUnit.SECONDS);
+            } catch (InterruptedException ignored) {
+            }
+            serverProcess.destroyForcibly();
+            serverProcess = null;
+        }
+    }
+
+    private static final String SSE_APP = """
+            main() {
+                var app = web.app()
+                app.sse("/events") {
+                    HANDLER
+                }
+                app.listen(PORT)
+            }
+            """;
+
+    private static Path testClassesDir() throws Exception {
+        return Path.of(KofWebSseE2ETest.class.getProtectionDomain()
+                .getCodeSource().getLocation().toURI()).toRealPath();
+    }
+
+    private int startSseServer(Path tempDir, String handlerBody) throws Exception {
+        return startServer(tempDir, SSE_APP.replace("HANDLER", handlerBody));
+    }
+
+    private int startServer(Path tempDir, String kofSource) throws Exception {
+        int port = freePort();
+        Path sourceFile = tempDir.resolve("App.kf");
+        Files.writeString(sourceFile, kofSource.replace("PORT", String.valueOf(port)));
+        Path outDir = tempDir.resolve("classes");
+        CompilerDriver driver = new CompilerDriver();
+        driver.setExternalClasspath(List.of(testClassesDir()));
+        CompilationResult result = driver.compile(sourceFile, outDir, Target.JVM);
+        assertTrue(result.success(), "Compilation should succeed: "
+                + result.diagnostics().getDiagnostics());
+        ProcessBuilder pb = new ProcessBuilder(JAVA_BIN, "-cp", outDir.toString(), "Default.Main");
+        pb.redirectErrorStream(true);
+        serverProcess = pb.start();
+        int attempt = 0;
+        while (attempt < 40) {
+            if (!serverProcess.isAlive()) {
+                String out = new String(serverProcess.getInputStream().readAllBytes(),
+                                StandardCharsets.UTF_8)
+                        .replace("\r\n", "\n").trim();
+                throw new IOException("server exited early: " + out);
+            }
+            try (Socket probe = new Socket()) {
+                probe.connect(new java.net.InetSocketAddress("127.0.0.1", port), 200);
+                return port;
+            } catch (IOException e) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+            attempt++;
+        }
+        throw new IOException("server did not start listening");
+    }
+
+    private int freePort() throws IOException {
+        try (ServerSocket probe = new ServerSocket(0)) {
+            return probe.getLocalPort();
+        }
+    }
+
+    private String request(int port, String raw) throws IOException {
+        try (Socket socket = new Socket("127.0.0.1", port)) {
+            socket.setSoTimeout(5000);
+            OutputStream out = socket.getOutputStream();
+            out.write(raw.getBytes(StandardCharsets.UTF_8));
+            out.flush();
+            StringBuilder response = new StringBuilder();
+            byte[] buffer = new byte[4096];
+            int n;
+            while ((n = socket.getInputStream().read(buffer)) != -1) {
+                response.append(new String(buffer, 0, n, StandardCharsets.UTF_8));
+            }
+            return response.toString();
+        }
+    }
+
+    private static final class SseClient implements AutoCloseable {
+        private final Socket socket;
+        private final BufferedReader in;
+        final String status;
+        final List<String> headers;
+
+        SseClient(int port) throws IOException {
+            this(port, "");
+        }
+
+        SseClient(int port, String query) throws IOException {
+            socket = new Socket("127.0.0.1", port);
+            socket.setSoTimeout(2000);
+            OutputStream out = socket.getOutputStream();
+            String target = query.isEmpty() ? "/events" : "/events?" + query;
+            out.write(("GET " + target + " HTTP/1.1\r\n"
+                    + "Host: 127.0.0.1\r\n"
+                    + "Accept: text/event-stream\r\n"
+                    + "\r\n").getBytes(StandardCharsets.UTF_8));
+            out.flush();
+            in = new BufferedReader(new InputStreamReader(
+                    socket.getInputStream(), StandardCharsets.UTF_8));
+            status = in.readLine();
+            headers = new ArrayList<>();
+            String line;
+            while ((line = in.readLine()) != null && !line.isEmpty()) {
+                headers.add(line);
+            }
+        }
+
+        String header(String name) {
+            for (String line : headers) {
+                int colon = line.indexOf(':');
+                if (colon > 0 && line.substring(0, colon).trim().equalsIgnoreCase(name)) {
+                    return line.substring(colon + 1).trim();
+                }
+            }
+            return null;
+        }
+
+        String readEvent() throws IOException {
+            StringBuilder frame = new StringBuilder();
+            while (true) {
+                String line = in.readLine();
+                if (line == null) {
+                    throw new IOException("SSE stream closed before event terminator");
+                }
+                if (line.isEmpty()) return frame.toString();
+                if (frame.length() > 0) frame.append('\n');
+                frame.append(line);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            socket.close();
+        }
+    }
+
+    private SseClient connect(int port) throws IOException {
+        return new SseClient(port);
+    }
+
+    private void assertHeaders(SseClient client) {
+        assertEquals("HTTP/1.1 200 OK", client.status);
+        assertEquals("text/event-stream", client.header("Content-Type"));
+        assertEquals("no-cache", client.header("Cache-Control"));
+        assertEquals("keep-alive", client.header("Connection"));
+        assertEquals("no", client.header("X-Accel-Buffering"));
+    }
+
+    @Test
+    void single_data_event(@TempDir Path tempDir) throws Exception {
+        int port = startSseServer(tempDir, "sse.send(\"hello\")");
+        try (SseClient client = connect(port)) {
+            assertHeaders(client);
+            assertEquals("data: hello", client.readEvent());
+        }
+    }
+
+    @Test
+    void named_event(@TempDir Path tempDir) throws Exception {
+        int port = startSseServer(tempDir, "sse.event(\"tick\", \"hello\")");
+        try (SseClient client = connect(port)) {
+            assertHeaders(client);
+            assertEquals("event: tick\ndata: hello", client.readEvent());
+        }
+    }
+
+    @Test
+    void multi_event_keeps_alive(@TempDir Path tempDir) throws Exception {
+        int port = startSseServer(tempDir, """
+                sse.send("one")
+                sse.send("two")
+                sse.send("three")
+                """);
+        try (SseClient client = connect(port)) {
+            assertHeaders(client);
+            assertEquals("data: one", client.readEvent());
+            assertEquals("data: two", client.readEvent());
+            assertEquals("data: three", client.readEvent());
+        }
+    }
+
+    @Test
+    void multi_line_data_splits(@TempDir Path tempDir) throws Exception {
+        int port = startSseServer(tempDir, "sse.send(\"line1\\nline2\")");
+        try (SseClient client = connect(port)) {
+            assertHeaders(client);
+            assertEquals("data: line1\ndata: line2", client.readEvent());
+        }
+    }
+
+    @Test
+    void client_close_no_crash(@TempDir Path tempDir) throws Exception {
+        int port = startSseServer(tempDir, "sse.send(\"hello\")");
+        try (SseClient client = connect(port)) {
+            assertEquals("data: hello", client.readEvent());
+        }
+        Thread.sleep(200);
+        try (SseClient client = connect(port)) {
+            assertHeaders(client);
+            assertEquals("data: hello", client.readEvent());
+        }
+    }
+
+    @Test
+    void many_concurrent_clients_independent(@TempDir Path tempDir) throws Exception {
+        int port = startSseServer(tempDir, "sse.send(\"client-\" + query(\"client\"))");
+        ExecutorService pool = Executors.newFixedThreadPool(10);
+        try {
+            List<Future<String>> results = new ArrayList<>();
+            for (int i = 0; i < 10; i++) {
+                final int n = i;
+                results.add(pool.submit(() -> {
+                    try (SseClient client = new SseClient(port, "client=" + n)) {
+                        assertHeaders(client);
+                        return client.readEvent();
+                    }
+                }));
+            }
+            for (int i = 0; i < results.size(); i++) {
+                assertEquals("data: client-" + i,
+                        results.get(i).get(10, TimeUnit.SECONDS));
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    void hello_route_still_works(@TempDir Path tempDir) throws Exception {
+        int port = startServer(tempDir, """
+                main() {
+                    var app = web.app()
+                    app.get("/hello") { return "Hello SSE" }
+                    app.listen(PORT)
+                }
+                """);
+        String r = request(port, "GET /hello HTTP/1.1\r\nHost: x\r\n\r\n");
+        assertTrue(r.startsWith("HTTP/1.1 200 OK"), r);
+        assertTrue(r.contains("Hello SSE"), r);
+    }
+}

--- a/kof-compiler/src/test/java/dev/kof/compiler/KofWebWsE2ETest.java
+++ b/kof-compiler/src/test/java/dev/kof/compiler/KofWebWsE2ETest.java
@@ -1,0 +1,280 @@
+package dev.kof.compiler;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * E2E tests for the RFC 6455 WebSocket handshake in the Kof-native web stack.
+ */
+class KofWebWsE2ETest {
+
+    private static final String JAVA_BIN = Path.of(
+            System.getProperty("java.home"), "bin", "java").toString();
+
+    private static final String VALID_HEADERS = "Upgrade: websocket\r\n"
+            + "Connection: Upgrade\r\n"
+            + "Sec-WebSocket-Version: 13\r\n"
+            + "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n";
+
+    private Process serverProcess;
+
+    @AfterEach
+    void stopServer() {
+        if (serverProcess != null) {
+            serverProcess.destroy();
+            try {
+                serverProcess.waitFor(5, TimeUnit.SECONDS);
+            } catch (InterruptedException ignored) {
+            }
+            serverProcess.destroyForcibly();
+            serverProcess = null;
+        }
+    }
+
+    private static Path testClassesDir() throws Exception {
+        return Path.of(KofWebWsE2ETest.class.getProtectionDomain()
+                .getCodeSource().getLocation().toURI()).toRealPath();
+    }
+
+    private int startServer(Path tempDir, String kofSource) throws Exception {
+        int port = freePort();
+        Path sourceFile = tempDir.resolve("App.kf");
+        Files.writeString(sourceFile, kofSource.replace("PORT", String.valueOf(port)));
+        Path outDir = tempDir.resolve("classes");
+        CompilerDriver driver = new CompilerDriver();
+        driver.setExternalClasspath(List.of(testClassesDir()));
+        CompilationResult result = driver.compile(sourceFile, outDir, Target.JVM);
+        assertTrue(result.success(), "Compilation should succeed: "
+                + result.diagnostics().getDiagnostics());
+        ProcessBuilder pb = new ProcessBuilder(JAVA_BIN, "-cp", outDir.toString(), "Default.Main");
+        pb.redirectErrorStream(true);
+        serverProcess = pb.start();
+        int attempt = 0;
+        while (attempt < 40) {
+            if (!serverProcess.isAlive()) {
+                String out = new String(serverProcess.getInputStream().readAllBytes(),
+                                StandardCharsets.UTF_8)
+                        .replace("\r\n", "\n").trim();
+                throw new IOException("server exited early: " + out);
+            }
+            try (Socket probe = new Socket()) {
+                probe.connect(new java.net.InetSocketAddress("127.0.0.1", port), 200);
+                return port;
+            } catch (IOException e) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+            attempt++;
+        }
+        throw new IOException("server did not start listening");
+    }
+
+    private int freePort() throws IOException {
+        try (ServerSocket probe = new ServerSocket(0)) {
+            return probe.getLocalPort();
+        }
+    }
+
+    private String request(int port, String raw) throws IOException {
+        try (Socket socket = new Socket("127.0.0.1", port)) {
+            socket.setSoTimeout(5000);
+            OutputStream out = socket.getOutputStream();
+            out.write(raw.getBytes(StandardCharsets.UTF_8));
+            out.flush();
+            StringBuilder response = new StringBuilder();
+            byte[] buffer = new byte[4096];
+            int n;
+            while ((n = socket.getInputStream().read(buffer)) != -1) {
+                response.append(new String(buffer, 0, n, StandardCharsets.UTF_8));
+            }
+            return response.toString();
+        }
+    }
+
+    private static final class WsResponse implements AutoCloseable {
+        private final Socket socket;
+        private final String status;
+        private final List<String> headers;
+
+        WsResponse(Socket socket, String status, List<String> headers) {
+            this.socket = socket;
+            this.status = status;
+            this.headers = headers;
+        }
+
+        String header(String name) {
+            for (String line : headers) {
+                int colon = line.indexOf(':');
+                if (colon > 0 && line.substring(0, colon).trim().equalsIgnoreCase(name)) {
+                    return line.substring(colon + 1).trim();
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public void close() throws IOException {
+            socket.close();
+        }
+    }
+
+    private WsResponse handshake(int port, String extraHeaders) throws IOException {
+        Socket socket = new Socket("127.0.0.1", port);
+        socket.setSoTimeout(5000);
+        OutputStream out = socket.getOutputStream();
+        out.write(("GET /ws HTTP/1.1\r\nHost: x\r\n"
+                + extraHeaders
+                + "\r\n").getBytes(StandardCharsets.UTF_8));
+        out.flush();
+        BufferedReader in = new BufferedReader(new InputStreamReader(
+                socket.getInputStream(), StandardCharsets.UTF_8));
+        String status = in.readLine();
+        List<String> headers = new ArrayList<>();
+        String line;
+        while ((line = in.readLine()) != null && !line.isEmpty()) {
+            headers.add(line);
+        }
+        return new WsResponse(socket, status, headers);
+    }
+
+    private String wsApp() {
+        return """
+                main() {
+                    var app = web.app()
+                    app.ws("/ws") { return "x" }
+                    app.listen(PORT)
+                }
+                """;
+    }
+
+    @Test
+    void handshake_101_with_correct_accept(@TempDir Path tempDir) throws Exception {
+        int port = startServer(tempDir, wsApp());
+        try (WsResponse response = handshake(port, VALID_HEADERS)) {
+            assertEquals("HTTP/1.1 101 Switching Protocols", response.status);
+            assertEquals("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=",
+                    response.header("Sec-WebSocket-Accept"));
+        }
+    }
+
+    @Test
+    void handshake_rejects_missing_key(@TempDir Path tempDir) throws Exception {
+        int port = startServer(tempDir, wsApp());
+        String response = request(port, "GET /ws HTTP/1.1\r\nHost: x\r\n"
+                + "Upgrade: websocket\r\n"
+                + "Connection: Upgrade\r\n"
+                + "Sec-WebSocket-Version: 13\r\n"
+                + "\r\n");
+        assertTrue(response.startsWith("HTTP/1.1 400 Bad Request"), response);
+    }
+
+    @Test
+    void handshake_rejects_old_version(@TempDir Path tempDir) throws Exception {
+        int port = startServer(tempDir, wsApp());
+        String response = request(port, "GET /ws HTTP/1.1\r\nHost: x\r\n"
+                + VALID_HEADERS.replace("Version: 13", "Version: 8")
+                + "\r\n");
+        assertTrue(response.startsWith("HTTP/1.1 400 Bad Request"), response);
+    }
+
+    @Test
+    void handshake_rejects_no_upgrade(@TempDir Path tempDir) throws Exception {
+        int port = startServer(tempDir, wsApp());
+        String response = request(port, "GET /ws HTTP/1.1\r\nHost: x\r\n"
+                + "Connection: Upgrade\r\n"
+                + "Sec-WebSocket-Version: 13\r\n"
+                + "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+                + "\r\n");
+        assertTrue(response.startsWith("HTTP/1.1 400 Bad Request"), response);
+    }
+
+    @Test
+    void handshake_rejects_no_connection_upgrade(@TempDir Path tempDir) throws Exception {
+        int port = startServer(tempDir, wsApp());
+        String response = request(port, "GET /ws HTTP/1.1\r\nHost: x\r\n"
+                + "Upgrade: websocket\r\n"
+                + "Sec-WebSocket-Version: 13\r\n"
+                + "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+                + "\r\n");
+        assertTrue(response.startsWith("HTTP/1.1 400 Bad Request"), response);
+    }
+
+    @Test
+    void handshake_keeps_socket_open(@TempDir Path tempDir) throws Exception {
+        int port = startServer(tempDir, wsApp());
+        try (WsResponse response = handshake(port, VALID_HEADERS)) {
+            assertEquals("HTTP/1.1 101 Switching Protocols", response.status);
+            Thread.sleep(300);
+            assertTrue(serverProcess.isAlive());
+            assertFalse(response.socket.isClosed());
+            assertEquals(0, response.socket.getInputStream().available());
+        }
+    }
+
+    /**
+     * Validates the case the previous substring-based validator broke:
+     * {@code Connection: keep-alive, Upgrade} carries the Upgrade token in a
+     * comma-separated list, not as the only value. RFC 6455 §4.1 requires it
+     * to be accepted.
+     */
+    @Test
+    void handshake_accepts_comma_separated_connection_tokens(@TempDir Path tempDir) throws Exception {
+        String headers = "Upgrade: websocket\r\n"
+                + "Connection: keep-alive, Upgrade\r\n"
+                + "Sec-WebSocket-Version: 13\r\n"
+                + "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n";
+        int port = startServer(tempDir, wsApp());
+        try (WsResponse response = handshake(port, headers)) {
+            assertEquals("HTTP/1.1 101 Switching Protocols", response.status);
+            assertEquals("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=", response.header("Sec-WebSocket-Accept"));
+        }
+    }
+
+    @Test
+    void handshake_alongside_http_and_sse(@TempDir Path tempDir) throws Exception {
+        String app = """
+                main() {
+                    var app = web.app()
+                    app.get("/hello") { return "Hello WS" }
+                    app.sse("/events") { sse.send("hello") }
+                    app.ws("/ws") { return "x" }
+                    app.listen(PORT)
+                }
+                """;
+        int port = startServer(tempDir, app);
+        String http = request(port, "GET /hello HTTP/1.1\r\nHost: x\r\n\r\n");
+        assertTrue(http.startsWith("HTTP/1.1 200 OK"), http);
+        assertTrue(http.contains("Hello WS"), http);
+        String sse = request(port, "GET /events HTTP/1.1\r\nHost: x\r\n"
+                + "Accept: text/event-stream\r\n\r\n");
+        assertTrue(sse.startsWith("HTTP/1.1 200 OK"), sse);
+        assertTrue(sse.contains("data: hello"), sse);
+        try (WsResponse ws = handshake(port, VALID_HEADERS)) {
+            assertEquals("HTTP/1.1 101 Switching Protocols", ws.status);
+            assertEquals("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=",
+                    ws.header("Sec-WebSocket-Accept"));
+        }
+    }
+}

--- a/kof-compiler/src/test/java/dev/kof/compiler/KofWebWsE2ETest.java
+++ b/kof-compiler/src/test/java/dev/kof/compiler/KofWebWsE2ETest.java
@@ -14,10 +14,12 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -169,6 +171,108 @@ class KofWebWsE2ETest {
                 """;
     }
 
+    private static final byte[] MASK = {0x12, 0x34, 0x56, 0x78};
+
+    private static void writeMaskedFrame(OutputStream out, int opcode, byte[] payload) throws IOException {
+        int len = payload.length;
+        byte[] frame;
+        int headerLen;
+        if (len <= 125) {
+            frame = new byte[2 + 4 + len];
+            frame[1] = (byte) (0x80 | len);
+            headerLen = 2;
+        } else if (len <= 0xFFFF) {
+            frame = new byte[4 + 4 + len];
+            frame[1] = (byte) (0x80 | 126);
+            frame[2] = (byte) ((len >> 8) & 0xFF);
+            frame[3] = (byte) (len & 0xFF);
+            headerLen = 4;
+        } else {
+            frame = new byte[10 + 4 + len];
+            frame[1] = (byte) (0x80 | 127);
+            for (int i = 0; i < 8; i++) {
+                frame[2 + i] = (byte) ((len >> (56 - i * 8)) & 0xFF);
+            }
+            headerLen = 10;
+        }
+        frame[0] = (byte) (0x80 | opcode);
+        System.arraycopy(MASK, 0, frame, headerLen, 4);
+        for (int i = 0; i < len; i++) {
+            frame[headerLen + 4 + i] = (byte) (payload[i] ^ MASK[i % 4]);
+        }
+        out.write(frame);
+        out.flush();
+    }
+
+    private static void writeOversizedFrameHeader(OutputStream out) throws IOException {
+        byte[] frame = new byte[14];
+        frame[0] = (byte) 0x82;
+        frame[1] = (byte) (0x80 | 127);
+        long len = (1L << 20) + 1;
+        for (int i = 0; i < 8; i++) {
+            frame[2 + i] = (byte) ((len >> (56 - i * 8)) & 0xFF);
+        }
+        System.arraycopy(MASK, 0, frame, 10, 4);
+        out.write(frame);
+        out.flush();
+    }
+
+    private static byte[] readServerFrame(java.io.InputStream in) throws IOException {
+        byte[] header = new byte[10];
+        readFully(in, header, 0, 2);
+        long len = header[1] & 0x7F;
+        int headerLen = 2;
+        if (len == 126) {
+            readFully(in, header, 2, 2);
+            len = ((header[2] & 0xFF) << 8) | (header[3] & 0xFF);
+            headerLen = 4;
+        } else if (len == 127) {
+            readFully(in, header, 2, 8);
+            len = 0;
+            for (int i = 0; i < 8; i++) {
+                len = (len << 8) | (header[2 + i] & 0xFF);
+            }
+            headerLen = 10;
+        }
+        byte[] payload = new byte[(int) len];
+        readFully(in, payload, 0, payload.length);
+        byte[] frame = new byte[headerLen + payload.length];
+        System.arraycopy(header, 0, frame, 0, headerLen);
+        System.arraycopy(payload, 0, frame, headerLen, payload.length);
+        return frame;
+    }
+
+    private static byte[] framePayload(byte[] frame) {
+        long len = frame[1] & 0x7F;
+        int offset;
+        if (len == 126) {
+            len = ((frame[2] & 0xFF) << 8) | (frame[3] & 0xFF);
+            offset = 4;
+        } else if (len == 127) {
+            len = 0;
+            for (int i = 0; i < 8; i++) {
+                len = (len << 8) | (frame[2 + i] & 0xFF);
+            }
+            offset = 10;
+        } else {
+            offset = 2;
+        }
+        return Arrays.copyOfRange(frame, offset, offset + (int) len);
+    }
+
+    private static int closeCode(byte[] payload) {
+        return ((payload[0] & 0xFF) << 8) | (payload[1] & 0xFF);
+    }
+
+    private static void readFully(java.io.InputStream in, byte[] buf, int off, int len) throws IOException {
+        while (len > 0) {
+            int n = in.read(buf, off, len);
+            if (n < 0) throw new IOException("EOF reading frame");
+            off += n;
+            len -= n;
+        }
+    }
+
     @Test
     void handshake_101_with_correct_accept(@TempDir Path tempDir) throws Exception {
         int port = startServer(tempDir, wsApp());
@@ -275,6 +379,45 @@ class KofWebWsE2ETest {
             assertEquals("HTTP/1.1 101 Switching Protocols", ws.status);
             assertEquals("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=",
                     ws.header("Sec-WebSocket-Accept"));
+        }
+    }
+
+    @Test
+    void ws_ping_pong_e2e(@TempDir Path tempDir) throws Exception {
+        int port = startServer(tempDir, wsApp());
+        try (WsResponse response = handshake(port, VALID_HEADERS)) {
+            byte[] payload = "pong-me".getBytes(StandardCharsets.UTF_8);
+            writeMaskedFrame(response.socket.getOutputStream(), 0x9, payload);
+            byte[] frame = readServerFrame(response.socket.getInputStream());
+            assertEquals(0x8A, frame[0] & 0xFF);
+            assertEquals(0, frame[1] & 0x80);
+            assertArrayEquals(payload, framePayload(frame));
+        }
+    }
+
+    @Test
+    void ws_close_e2e(@TempDir Path tempDir) throws Exception {
+        int port = startServer(tempDir, wsApp());
+        try (WsResponse response = handshake(port, VALID_HEADERS)) {
+            byte[] close = {0x03, (byte) 0xE8};
+            writeMaskedFrame(response.socket.getOutputStream(), 0x8, close);
+            byte[] frame = readServerFrame(response.socket.getInputStream());
+            assertEquals(0x88, frame[0] & 0xFF);
+            assertEquals(0, frame[1] & 0x80);
+            assertEquals(1000, closeCode(framePayload(frame)));
+            assertEquals(-1, response.socket.getInputStream().read());
+        }
+    }
+
+    @Test
+    void ws_rejects_oversized_frame_e2e(@TempDir Path tempDir) throws Exception {
+        int port = startServer(tempDir, wsApp());
+        try (WsResponse response = handshake(port, VALID_HEADERS)) {
+            writeOversizedFrameHeader(response.socket.getOutputStream());
+            byte[] frame = readServerFrame(response.socket.getInputStream());
+            assertEquals(0x88, frame[0] & 0xFF);
+            assertEquals(0, frame[1] & 0x80);
+            assertEquals(1009, closeCode(framePayload(frame)));
         }
     }
 }

--- a/kof-compiler/src/test/java/dev/kof/compiler/KofWsFrameTest.java
+++ b/kof-compiler/src/test/java/dev/kof/compiler/KofWsFrameTest.java
@@ -1,0 +1,154 @@
+package dev.kof.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pure unit tests for the RFC 6455 frame codec generated into KofRuntime.
+ */
+class KofWsFrameTest {
+
+    private static final byte[] MASK = {0x12, 0x34, 0x56, 0x78};
+    private static final Class<?> WS_FRAME = loadWsFrame();
+
+    private static Class<?> loadWsFrame() {
+        try {
+            Path out = Files.createTempDirectory("kof-ws-frame-test");
+            JvmRuntime.ensureCompiled(out, List.of());
+            URLClassLoader loader = new URLClassLoader(
+                    new URL[]{out.toUri().toURL()},
+                    KofWsFrameTest.class.getClassLoader());
+            return Class.forName("dev.kof.runtime.KofRuntime$WsFrame", true, loader);
+        } catch (Exception e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private static byte[] encode(int opcode, byte[] payload, boolean fin) throws Exception {
+        return (byte[]) WS_FRAME.getMethod("encode", int.class, byte[].class, boolean.class)
+                .invoke(null, opcode, payload, fin);
+    }
+
+    private static Object decodeClient(byte[] frame) throws Exception {
+        try {
+            return WS_FRAME.getMethod("decodeClient", byte[].class)
+                    .invoke(null, (Object) frame);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof Exception ex) throw ex;
+            throw e;
+        }
+    }
+
+    private static Object field(Object frame, String name) throws Exception {
+        Field f = WS_FRAME.getDeclaredField(name);
+        f.setAccessible(true);
+        return f.get(frame);
+    }
+
+    private static byte[] masked(byte[] serverFrame) {
+        long len = serverFrame[1] & 0x7F;
+        int headerLen;
+        if (len == 126) headerLen = 4;
+        else if (len == 127) headerLen = 10;
+        else headerLen = 2;
+        byte[] out = new byte[serverFrame.length + 4];
+        System.arraycopy(serverFrame, 0, out, 0, headerLen);
+        out[1] = (byte) (serverFrame[1] | 0x80);
+        System.arraycopy(MASK, 0, out, headerLen, 4);
+        for (int i = 0; i < serverFrame.length - headerLen; i++) {
+            out[headerLen + 4 + i] = (byte) (serverFrame[headerLen + i] ^ MASK[i % 4]);
+        }
+        return out;
+    }
+
+    private static byte[] oversizedClientFrame() {
+        byte[] out = new byte[14];
+        out[0] = (byte) 0x81;
+        out[1] = (byte) 0xFF;
+        long len = (1L << 20) + 1;
+        for (int i = 0; i < 8; i++) {
+            out[2 + i] = (byte) ((len >> (56 - i * 8)) & 0xFF);
+        }
+        System.arraycopy(MASK, 0, out, 10, 4);
+        return out;
+    }
+
+    private static byte[] payload(int size) {
+        byte[] payload = new byte[size];
+        for (int i = 0; i < payload.length; i++) {
+            payload[i] = (byte) (i % 251);
+        }
+        return payload;
+    }
+
+    private static void assertDecoded(byte[] payload, Object frame) throws Exception {
+        assertTrue((Boolean) field(frame, "fin"));
+        assertEquals(0x1, field(frame, "opcode"));
+        assertArrayEquals(payload, (byte[]) field(frame, "payload"));
+    }
+
+    @Test
+    void encode_decode_text_small_payload() throws Exception {
+        byte[] payload = "hello ws".getBytes(StandardCharsets.UTF_8);
+        assertDecoded(payload, decodeClient(masked(encode(0x1, payload, true))));
+    }
+
+    @Test
+    void encode_decode_text_medium_payload() throws Exception {
+        byte[] payload = payload(300);
+        assertDecoded(payload, decodeClient(masked(encode(0x1, payload, true))));
+    }
+
+    @Test
+    void encode_decode_text_huge_payload() throws Exception {
+        byte[] payload = payload(70_000);
+        assertDecoded(payload, decodeClient(masked(encode(0x1, payload, true))));
+    }
+
+    @Test
+    void decode_rejects_unmasked_frame() {
+        assertThrows(IOException.class,
+                () -> decodeClient(encode(0x1, "x".getBytes(StandardCharsets.UTF_8), true)));
+    }
+
+    @Test
+    void decode_rejects_oversized_frame() {
+        assertThrows(IOException.class, () -> decodeClient(oversizedClientFrame()));
+    }
+
+    @Test
+    void round_trip_text_with_correct_mask() throws Exception {
+        byte[] payload = "masked".getBytes(StandardCharsets.UTF_8);
+        byte[] client = masked(encode(0x1, payload, true));
+        assertNotEquals(0, client[1] & 0x80);
+        assertDecoded(payload, decodeClient(client));
+
+        byte[] server = encode(0x1, payload, true);
+        assertEquals(0, server[1] & 0x80);
+        assertThrows(IOException.class, () -> decodeClient(server));
+    }
+
+    @Test
+    void encode_unmasked_server_frame() throws Exception {
+        for (int size : new int[]{0, 125, 126, 65_536}) {
+            byte[] frame = encode(0x1, payload(size), true);
+            assertEquals(0, frame[1] & 0x80, "mask bit for size " + size);
+        }
+    }
+}


### PR DESCRIPTION
This PR combines the **WS frame codec (PR4)** and the **idiomatic Kof API (PR5)** for WebSocket on the JVM target. Stacked on PR #16 (PR3 handshake), PR #15 (PR2 SSE), and PR #14 (PR1 persistent connection).

## Public API

```kof
main() {
    var app = web.app()

    app.ws("/chat") {
        ws.onMessage { msg ->
            ws.send("echo: " + msg)
        }

        ws.onClose { (code, reason) ->
            // do something on close
        }
    }

    app.listen(8080)
}
```

## Wire-level lifecycle (PR3 + PR4)

- **Handshake.** RFC 6455 §4.1 validation (`Upgrade: websocket`, `Connection: Upgrade`, `Sec-WebSocket-Version: 13`, `Sec-WebSocket-Key` present) implemented via the parsed header map and a `containsToken` helper that respects RFC 7230 §3.2.2 comma-separated token lists. A comma-separated `Connection: keep-alive, Upgrade` is accepted — the original substring-match prototype would have rejected this.
- **Frame codec.** `WsFrame.encode` (server -> client, unmasked) and `WsFrame.decodeClient` (client -> server, masked). Handles 7-/16-/64-bit payload lengths. `WsConnection.sendText/sendBinary/ping/pong/close` write unmasked server frames.
- **Lifecycle.** PING -> PONG with the same payload; CLOSE -> ack CLOSE 1000; oversize -> CLOSE 1009; missing MASK -> CLOSE 1002; `FIN=0` -> CLOSE 1003 (fragmentation rejected by design); TEXT -> route to `onMessage`; CLOSE -> route to `onClose` then ack.

## API surface (PR5)

- **Trailing-block sugar.** `app.ws(path) { body }` is rewritten in `SemanticAnalyzer` to `app.ws(path, (ws: KofRuntime$WsConnection) -> { body })` — same pattern used for SSE in PR2. The body executes once per connection and registers callbacks by assignment to `ws.onOpen` / `ws.onMessage` / `ws.onClose`.
- **Handler invocation.** `kof_ws_invoke` reflectively dispatches a `LambdaN` by arity (non-synthetic public `invoke` methods). Mirrors `kof_ho_invoke`.
- **Connection hoisting.** `WsConnection` is constructed once per connection (was rebuilt per frame in PR4's first cut) and reused across `pong`/`close`/frame-loop iterations.
- **`send(Object)` overload** accepts the user's `msg` (Java bytecode sees it as `Object`); `sendText(String)` remains the typed path.
- **`onClose(int, String)`** accepts a two-arg lambda `{ (code, reason) -> ... }`; `kof_ws_invoke` autoboxes the integer.

## New parser surface

Trailing-block lambdas with parameters (`{ msg -> ... }` and `{ (code, reason) -> ... }`) previously failed with `PARSE025` or `PARSE042`. Parser now distinguishes:
- `{ identifier -> ... }` — single-param trailing lambda;
- `{ (a, b, ...) -> ... }` — explicit-param-list trailing lambda;
- bare `{ ... }` — the previous no-arg case (unchanged).

This is needed because the WS handler body uses `{ msg -> ... }` and `{ (code, reason) -> ... }`. Existing trailing-block users (HTTP route bodies, SSE bodies, `kof.spawn { ... }`, transaction bodies) keep working because the no-arg path is unchanged.

## Bugfix surfacing

The PR5 surface exposed a latent compiler bug: lambdas with **both** captures and parameters were emitting bytecode that the JVM verifier rejected (`VerifyError: bad local variable type`). `CompilerDriver.lowerLambda` registered locals in capture-then-param order, but the IR generator emits stores in the same order, so the local index was off by N captures. Fixed by registering params first. `LambdaE2ETest.mutatingCaptureStillWorks` is the regression that catches it; we add `KofWebWsE2ETest.ws_onMessage_echo_text` to cover the WS path explicitly.

## File-by-file

| File | Change |
| --- | --- |
| `kof-compiler/.../JvmWebRuntime.java` | `WsFrame` (encode/decode + RFC 6455 limits + close codes). `WsConnection`: hoisted per connection, public `onOpen`/`onMessage`/`onClose` fields + setter methods, `send(String)` + `send(Object)` overloads. |
| `kof-compiler/.../JvmRuntime.java` | `kof_web_handle` now passes the matched `WebRoute.handler` into `kof_web_ws_handshake`. The post-handshake body invokes `kof_web_invoke(handler, conn)` once to register callbacks, then enters the frame loop using the hoisted `conn`. TEXT routes to `conn.onMessage`; CLOSE routes to `conn.onClose` (with code/reason parsing) before the ack. New `kof_ws_invoke` helper. New `kof_web_invoke(Object, WsConnection)` overload paralleling the SSE one. |
| `kof-compiler/.../KofWeb.java` | Synthetic `WS_CONNECTION` type mirroring SSE; `isWsConnectionType` and `wsConnectionMethod` switch for `sendText`/`sendBinary`/`send`/`close`/`onOpen`/`onMessage`/`onClose`. |
| `kof-compiler/.../SemanticAnalyzer.java` | Trailing-block rewrite: `app.ws(path, lambda_no_params)` -> `app.ws(path, (ws: KofRuntime$WsConnection) -> body)`. Receiver-type dispatch falls through to `wsConnectionMethod`. |
| `kof-compiler/.../Parser.java` | New `parseLambdaBlock()` that recognizes trailing-block-with-parameters; refactor of `looksLikeLambdaParams` to accept a lookahead offset (the changes are non-breaking — only three call sites, all updated). |
| `kof-compiler/.../CompilerDriver.java` | Local registration order fix (params before captures) in `lowerLambda`. |
| `kof-compiler/src/test/.../KofWebWsE2ETest.java` | 11 -> 16 tests: +`ws_onMessage_echo_text`, +`ws_onMessage_receives_multiple_frames`, +`ws_onClose_called_when_client_closes`, +`ws_no_callback_keeps_ping_and_close` (regression), +`ws_handler_exception_closes_connection_gracefully`. |
| `kof-compiler/src/test/.../KofWsFrameTest.java` | **New.** 7 pure-JUnit codec tests (small/medium/huge payload round-trip, mask bit enforcement, oversized frame rejection, full client→server→server→client round-trip). |

## Public API impact

- `app.sse(path) { ... }` continues to work (PR2).
- `app.ws(path) { ... }` now does something useful: the body's `ws.onMessage { msg -> ws.send(msg) }` echoes each received text frame back to the client.

## Risks captured

- `ws.onOpen` is wired through the compiler sugar (and accepted by `wsConnectionMethod`) but the runtime doesn't yet emit an `onOpen()` invocation — there's no obvious phase to fire it on. PR6 or follow-up PR adds it once we decide on a definition (post-101, first interaction, etc.).
- Binary message handler (`0x2`) is registered but discards the frame. The Kof side can call `ws.sendBinary(...)` regardless; the server cannot yet echo binary. Future PR.
- `ws.ping(...)` from Kof compiles and works; we don't have tests for the Kof→server round-trip path. Tests cover server→Kof PONG only. Future PR.

## Verification

```
mvn -pl kof-compiler -am test -Dtest='KofWebE2ETest,KofWebTlsTest,KofWebSseE2ETest,KofWebWsE2ETest,KofWsFrameTest'
→ Tests run: 45, Failures: 0, Errors: 0, Skipped: 0
→ BUILD SUCCESS

mvn -pl kof-compiler -am test (full suite)
→ 652 tests, 197 pre-existing Native backend failures on this host (unchanged, .section directive rejection by `as`); JVM and TLS green.
```

## Out of scope (subsequent PRs)

PR6 — Hardening (concurrent connection cap, per-event deadlines, JS/Native stubs).
PR7 — Doc sync (`stdlib-web`, `status`, `backend-parity`, `ecosystem-coverage`, `CHANGELOG`).