### PR TITLE
feat(web): WebSocket idomatic api (onMessage/onClose/send)

### DIFF
--- a/kof-compiler/src/main/java/dev/kof/compiler/JvmRuntime.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/JvmRuntime.java
@@ -558,7 +558,7 @@ static boolean hasRuntimeFn(String methodName) {
                             return;
                         }
                         if (result.kind == RouteKind.WS) {
-                            kof_web_ws_handshake(req, client);
+                            kof_web_ws_handshake(req, client, result.route.handler);
                             return;
                         }
                         client.getOutputStream().write(result.response.getBytes(java.nio.charset.StandardCharsets.UTF_8));
@@ -572,7 +572,8 @@ static boolean hasRuntimeFn(String methodName) {
                 // loop with a frame codec and per-connection timeout handling.
                 private static final int KEEPALIVE_IDLE_MS = 300_000;
 
-                private static void kof_web_ws_handshake(WebRequest req, java.net.Socket client)
+                private static void kof_web_ws_handshake(
+                        WebRequest req, java.net.Socket client, Object handler)
                         throws java.io.IOException {
                     String upgradeVal = req.headers.get("upgrade");
                     String connectionVal = req.headers.get("connection");
@@ -604,10 +605,26 @@ static boolean hasRuntimeFn(String methodName) {
                     out.flush();
 
                     // Frame loop (PR4): handles RFC 6455 frame codec.
-                    // PING -> PONG; CLOSE -> ack CLOSE; oversize -> CLOSE 1009.
-                    // TEXT/BINARY frames are discarded for now (PR5 wires the
-                    // Kof handler).
+                    // PING -> PONG; CLOSE -> onClose + ack CLOSE;
+                    // oversize -> CLOSE 1009; TEXT -> onMessage.
                     client.setSoTimeout(KEEPALIVE_IDLE_MS);
+                    WsConnection conn = new WsConnection(client.getOutputStream());
+
+                    // Invoke the Kof handler body once. The body uses
+                    // ws.onMessage { ... } / ws.onClose { ... } to register
+                    // callbacks on `conn`.
+                    try {
+                        KOF_WEB_REQUEST.set(req);
+                        try {
+                            kof_web_invoke(handler, conn);
+                        } finally {
+                            KOF_WEB_REQUEST.remove();
+                        }
+                    } catch (Exception e) {
+                        System.err.println("kof web ws handler error: " + e.getMessage());
+                        return;
+                    }
+
                     try {
                         frameLoop: while (true) {
                             // 1) Read until we have at least 2 bytes for the header
@@ -633,7 +650,6 @@ static boolean hasRuntimeFn(String methodName) {
                                 plen = 0;
                                 for (int i = 0; i < 8; i++) plen = (plen << 8) | (ext[i] & 0xFF);
                             }
-                            WsConnection conn = new WsConnection(client.getOutputStream());
                             if (!fin) {
                                 conn.close(WsFrame.CLOSE_UNSUPPORTED, "fragmented frames not supported");
                                 break frameLoop;
@@ -659,14 +675,61 @@ static boolean hasRuntimeFn(String methodName) {
                             // 5) React
                             if (op == 0x9 /* PING */) { conn.pong(payload); }
                             else if (op == 0xA /* PONG */) { /* ignore */ }
-                            else if (op == 0x8 /* CLOSE */) { conn.close(1000, ""); break frameLoop; }
-                            // TEXT/BINARY/CONT: discard for now (PR5)
+                            else if (op == 0x1 /* TEXT */) {
+                                if (conn.onMessage != null) {
+                                    String text = new String(payload,
+                                            java.nio.charset.StandardCharsets.UTF_8);
+                                    try {
+                                        kof_ws_invoke(conn.onMessage, new Object[]{text});
+                                    } catch (Exception e) {
+                                        System.err.println("kof web ws onMessage error: "
+                                                + e.getMessage());
+                                        conn.close(WsFrame.CLOSE_SERVER_ERROR, "handler error");
+                                        break frameLoop;
+                                    }
+                                }
+                            }
+                            else if (op == 0x2 /* BINARY */) {
+                                // Binary messages are discarded in v1.
+                            }
+                            else if (op == 0x8 /* CLOSE */) {
+                                int code = 1000;
+                                String reason = "";
+                                if (payload.length >= 2) {
+                                    code = ((payload[0] & 0xFF) << 8) | (payload[1] & 0xFF);
+                                }
+                                if (payload.length > 2) {
+                                    reason = new String(payload, 2, payload.length - 2,
+                                            java.nio.charset.StandardCharsets.UTF_8);
+                                }
+                                if (conn.onClose != null) {
+                                    try {
+                                        kof_ws_invoke(conn.onClose, new Object[]{code, reason});
+                                    } catch (Exception e) {
+                                        System.err.println("kof web ws onClose error: "
+                                                + e.getMessage());
+                                    }
+                                }
+                                conn.close(1000, "");
+                                break frameLoop;
+                            }
                         }
                     } catch (java.net.SocketTimeoutException idle) {
                         // graceful close after KEEPALIVE_IDLE_MS
                     } catch (java.io.IOException eof) {
                         // client closed
                     }
+                }
+
+                /** Invoke a LambdaN by arity; used by the WS frame loop. */
+                private static Object kof_ws_invoke(Object handler, Object[] args) throws Exception {
+                    for (java.lang.reflect.Method m : handler.getClass().getMethods()) {
+                        if (!"invoke".equals(m.getName())) continue;
+                        if (m.getParameterCount() != args.length) continue;
+                        if (m.isSynthetic()) continue;
+                        try { return m.invoke(handler, args); } catch (IllegalArgumentException ignored) {}
+                    }
+                    throw new NoSuchMethodException("invoke(" + args.length + ")");
                 }
 
                 private static void readFully(java.io.InputStream in, byte[] buf) throws java.io.IOException {
@@ -778,6 +841,11 @@ static boolean hasRuntimeFn(String methodName) {
                 private static Object kof_web_invoke(Object target, SseConnection sse) throws Exception {
                     return target.getClass().getMethod("invoke", SseConnection.class)
                             .invoke(target, sse);
+                }
+
+                private static Object kof_web_invoke(Object target, WsConnection ws) throws Exception {
+                    return target.getClass().getMethod("invoke", WsConnection.class)
+                            .invoke(target, ws);
                 }
 
                 private static String kof_web_build(int status, String statusText, String body) {

--- a/kof-compiler/src/main/java/dev/kof/compiler/JvmWebRuntime.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/JvmWebRuntime.java
@@ -288,17 +288,33 @@ final class JvmWebRuntime {
                     public static final int CLOSE_TOO_BIG = 1009;
                     public static final int CLOSE_PROTOCOL_ERROR = 1002;
                     public static final int CLOSE_UNSUPPORTED = 1003;
+                    public static final int CLOSE_SERVER_ERROR = 1011;
                 }
 
                 public static final class WsConnection {
                     private final java.io.OutputStream out;
                     private final java.util.concurrent.locks.ReentrantLock writeLock =
                             new java.util.concurrent.locks.ReentrantLock();
+                    // Lambdas registradas pelo usuário via `ws.onMessage { ... }`
+                    // etc. Campos públicos para leitura rápida no frame loop.
+                    public Object onOpen;
+                    public Object onMessage;
+                    public Object onClose;
 
                     WsConnection(java.io.OutputStream out) {
                         this.out = out;
                     }
 
+                    public void onOpen(Object handler) { this.onOpen = handler; }
+                    public void onMessage(Object handler) { this.onMessage = handler; }
+                    public void onClose(Object handler) { this.onClose = handler; }
+
+                    public void send(String s) {
+                        sendText(s);
+                    }
+                    public void send(Object value) {
+                        sendText(String.valueOf(value));
+                    }
                     public void sendText(String s) {
                         send(WsFrame.encode(0x1, s.getBytes(java.nio.charset.StandardCharsets.UTF_8), true));
                     }

--- a/kof-compiler/src/main/java/dev/kof/compiler/KofWeb.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/KofWeb.java
@@ -27,6 +27,8 @@ final class KofWeb {
     static final Type APP = new Type.ClassType("kof.web", "App", List.of());
     static final Type SSE_CONNECTION =
             new Type.ClassType("dev.kof.runtime", "KofRuntime$SseConnection", List.of());
+    static final Type WS_CONNECTION =
+            new Type.ClassType("dev.kof.runtime", "KofRuntime$WsConnection", List.of());
 
     private static final Type STR = BuiltinTypes.STRING;
     private static final Type INT = Type.PrimitiveType.INT;
@@ -44,6 +46,10 @@ final class KofWeb {
         return SSE_CONNECTION.equals(t);
     }
 
+    static boolean isWsConnectionType(Type t) {
+        return WS_CONNECTION.equals(t);
+    }
+
     /** Methods available on the synthetic {@code sse} handler parameter. */
     static WebCall sseConnectionMethod(String name, List<Type> argTypes) {
         return switch (name) {
@@ -55,6 +61,23 @@ final class KofWeb {
                     ? new WebCall(name, VOID, List.of()) : null;
             case "isOpen" -> argTypes.isEmpty()
                     ? new WebCall(name, Type.PrimitiveType.BOOL, List.of()) : null;
+            default -> null;
+        };
+    }
+
+    /** Methods available on the synthetic {@code ws} handler parameter. */
+    static WebCall wsConnectionMethod(String name, List<Type> argTypes) {
+        return switch (name) {
+            case "send", "sendText" -> argTypes.size() == 1
+                    ? new WebCall(name, VOID, List.of(STR)) : null;
+            case "sendBinary" -> argTypes.size() == 1
+                    ? new WebCall(name, VOID, List.of(new Type.ArrayType(
+                            Type.PrimitiveType.BYTE))) : null;
+            case "close" -> argTypes.size() == 2
+                    ? new WebCall(name, VOID, List.of(INT, BuiltinTypes.STRING)) : null;
+            case "onMessage", "onClose", "onOpen" -> argTypes.size() == 1
+                    ? new WebCall(name, VOID, List.of(
+                            new Type.ClassType("java.lang", "Object", List.of()))) : null;
             default -> null;
         };
     }

--- a/kof-compiler/src/main/java/dev/kof/compiler/SemanticAnalyzer.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/SemanticAnalyzer.java
@@ -10,6 +10,8 @@ class SemanticAnalyzer {
 
     private static final String SSE_CONNECTION_TYPE =
             "dev.kof.runtime.KofRuntime$SseConnection";
+    private static final String WS_CONNECTION_TYPE =
+            "dev.kof.runtime.KofRuntime$WsConnection";
 
     private SymbolTable currentScope;
     private CompilationUnitNode currentUnit;
@@ -1246,6 +1248,13 @@ class SemanticAnalyzer {
                                     List.of(new FormalParameterNode(le.position(), List.of(),
                                             SSE_CONNECTION_TYPE, "sse")), le.body()));
                         }
+                        if ("ws".equals(mc.methodName()) && mc.arguments().size() == 2
+                                && mc.arguments().get(1) instanceof LambdaExpr le
+                                && le.parameters().isEmpty()) {
+                            mc.arguments().set(1, new LambdaExpr(le.position(),
+                                    List.of(new FormalParameterNode(le.position(), List.of(),
+                                            WS_CONNECTION_TYPE, "ws")), le.body()));
+                        }
                         List<Type> argTypes = new ArrayList<>();
                         for (ExpressionNode arg : mc.arguments()) argTypes.add(inferType(arg, scope));
                         KofWeb.WebCall webCall = KofWeb.instanceMethod(mc.methodName(), argTypes);
@@ -1257,6 +1266,13 @@ class SemanticAnalyzer {
                         for (ExpressionNode arg : mc.arguments()) argTypes.add(inferType(arg, scope));
                         KofWeb.WebCall sseCall = KofWeb.sseConnectionMethod(mc.methodName(), argTypes);
                         if (sseCall != null) yield sseCall.returnType();
+                        yield Type.UnknownType.UNKNOWN;
+                    }
+                    if (KofWeb.isWsConnectionType(recvType)) {
+                        List<Type> argTypes = new ArrayList<>();
+                        for (ExpressionNode arg : mc.arguments()) argTypes.add(inferType(arg, scope));
+                        KofWeb.WebCall wsCall = KofWeb.wsConnectionMethod(mc.methodName(), argTypes);
+                        if (wsCall != null) yield wsCall.returnType();
                         yield Type.UnknownType.UNKNOWN;
                     }
                     if (recvType instanceof Type.FunctionType ft) {

--- a/kof-compiler/src/test/java/dev/kof/compiler/KofWebWsE2ETest.java
+++ b/kof-compiler/src/test/java/dev/kof/compiler/KofWebWsE2ETest.java
@@ -242,6 +242,13 @@ class KofWebWsE2ETest {
         return frame;
     }
 
+    private static String readTextFrame(java.io.InputStream in) throws IOException {
+        byte[] frame = readServerFrame(in);
+        assertEquals(0x81, frame[0] & 0xFF);
+        assertEquals(0, frame[1] & 0x80);
+        return new String(framePayload(frame), StandardCharsets.UTF_8);
+    }
+
     private static byte[] framePayload(byte[] frame) {
         long len = frame[1] & 0x7F;
         int offset;
@@ -380,6 +387,121 @@ class KofWebWsE2ETest {
             assertEquals("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=",
                     ws.header("Sec-WebSocket-Accept"));
         }
+    }
+
+    @Test
+    void ws_onMessage_echo_text(@TempDir Path tempDir) throws Exception {
+        String app = """
+                main() {
+                    var app = web.app()
+                    app.ws("/ws") {
+                        ws.onMessage { msg -> ws.send(msg) }
+                    }
+                    app.listen(PORT)
+                }
+                """;
+        int port = startServer(tempDir, app);
+        try (WsResponse response = handshake(port, VALID_HEADERS)) {
+            writeMaskedFrame(response.socket.getOutputStream(), 0x1,
+                    "hello".getBytes(StandardCharsets.UTF_8));
+            byte[] frame = readServerFrame(response.socket.getInputStream());
+            assertEquals(0x81, frame[0] & 0xFF);
+            assertEquals(0, frame[1] & 0x80);
+            assertEquals("hello", new String(framePayload(frame), StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    void ws_onMessage_receives_multiple_frames(@TempDir Path tempDir) throws Exception {
+        String app = """
+                main() {
+                    var app = web.app()
+                    app.ws("/ws") {
+                        ws.onMessage { msg -> ws.send("echo: " + msg) }
+                    }
+                    app.listen(PORT)
+                }
+                """;
+        int port = startServer(tempDir, app);
+        try (WsResponse response = handshake(port, VALID_HEADERS)) {
+            java.io.OutputStream out = response.socket.getOutputStream();
+            writeMaskedFrame(out, 0x1, "one".getBytes(StandardCharsets.UTF_8));
+            assertEquals("echo: one", readTextFrame(response.socket.getInputStream()));
+            writeMaskedFrame(out, 0x1, "c".getBytes(StandardCharsets.UTF_8));
+            assertEquals("echo: c", readTextFrame(response.socket.getInputStream()));
+            writeMaskedFrame(out, 0x1, "def".getBytes(StandardCharsets.UTF_8));
+            assertEquals("echo: def", readTextFrame(response.socket.getInputStream()));
+        }
+    }
+
+    @Test
+    void ws_onClose_called_when_client_closes(@TempDir Path tempDir) throws Exception {
+        String app = """
+                main() {
+                    var app = web.app()
+                    app.ws("/ws") {
+                        ws.onClose { code, reason -> ws.send("closed") }
+                    }
+                    app.listen(PORT)
+                }
+                """;
+        int port = startServer(tempDir, app);
+        try (WsResponse response = handshake(port, VALID_HEADERS)) {
+            byte[] close = {0x03, (byte) 0xE8};
+            writeMaskedFrame(response.socket.getOutputStream(), 0x8, close);
+            assertEquals("closed", readTextFrame(response.socket.getInputStream()));
+            byte[] frame = readServerFrame(response.socket.getInputStream());
+            assertEquals(0x88, frame[0] & 0xFF);
+            assertEquals(0, frame[1] & 0x80);
+            assertEquals(1000, closeCode(framePayload(frame)));
+            assertEquals(-1, response.socket.getInputStream().read());
+        }
+    }
+
+    @Test
+    void ws_no_callback_still_does_handshake_and_ping_pong(@TempDir Path tempDir) throws Exception {
+        String app = """
+                main() {
+                    var app = web.app()
+                    app.ws("/ws") {
+                    }
+                    app.listen(PORT)
+                }
+                """;
+        int port = startServer(tempDir, app);
+        try (WsResponse response = handshake(port, VALID_HEADERS)) {
+            assertEquals("HTTP/1.1 101 Switching Protocols", response.status);
+            byte[] payload = "pong-me".getBytes(StandardCharsets.UTF_8);
+            writeMaskedFrame(response.socket.getOutputStream(), 0x9, payload);
+            byte[] frame = readServerFrame(response.socket.getInputStream());
+            assertEquals(0x8A, frame[0] & 0xFF);
+            assertEquals(0, frame[1] & 0x80);
+            assertArrayEquals(payload, framePayload(frame));
+        }
+    }
+
+    @Test
+    void ws_handler_exception_closes_connection_gracefully(@TempDir Path tempDir) throws Exception {
+        String app = """
+                main() {
+                    var app = web.app()
+                    app.ws("/ws") {
+                        ws.onMessage { msg -> throw "boom" }
+                    }
+                    app.listen(PORT)
+                }
+                """;
+        int port = startServer(tempDir, app);
+        try (WsResponse response = handshake(port, VALID_HEADERS)) {
+            writeMaskedFrame(response.socket.getOutputStream(), 0x1,
+                    "hello".getBytes(StandardCharsets.UTF_8));
+            byte[] frame = readServerFrame(response.socket.getInputStream());
+            assertEquals(0x88, frame[0] & 0xFF);
+            assertEquals(0, frame[1] & 0x80);
+            assertEquals(1011, closeCode(framePayload(frame)));
+            assertEquals(-1, response.socket.getInputStream().read());
+        }
+        assertTrue(serverProcess.isAlive());
     }
 
     @Test


### PR DESCRIPTION
This PR adds the idiomatic Kof API on top of PR #17 (frame codec + handshake). It was rebased manually onto `upstream/main` because the original `codex/pr4-ws-frames` branch had already been merged upstream without the PR5 work.

## Public API

```kof
main() {
    var app = web.app()

    app.ws("/chat") {
        ws.onMessage { msg ->
            ws.send("echo: " + msg)
        }

        ws.onClose { code, reason ->
            // do something on close
        }
    }

    app.listen(8080)
}
```

## What is in this PR

The five surviving files are the WS API surface only — the locals-reorder bugfix and the trailing-block parser logic that the original PR5 carried were already independently fixed in upstream (`aaec9c8` etc.), so duplicating them here would have caused a much larger diff with no additional value.

| File | Change |
| --- | --- |
| `kof-compiler/.../JvmWebRuntime.java` | `WsConnection`: hoisted per connection (was rebuilt per frame in PR4's first cut). Public `onOpen`/`onMessage`/`onClose` fields + setter methods. `send(String)` and `send(Object)` overloads — the latter accepts the user's lambda capture which arrives as `Object` at the bytecode level before any `String` specialization. |
| `kof-compiler/.../JvmRuntime.java` | `kof_web_handle` passes `WebRoute.handler` to `kof_web_ws_handshake`. The post-handshake body invokes `kof_web_invoke(handler, conn)` once to register callbacks, then enters the frame loop. TEXT routes to `conn.onMessage`; CLOSE routes to `conn.onClose` (with code/reason parsing) before the ack. New `kof_ws_invoke` helper (reflection-by-arity mirroring `kof_ho_invoke`). New `kof_web_invoke(Object, WsConnection)` overload paralleling the SSE one. |
| `kof-compiler/.../KofWeb.java` | Synthetic `WS_CONNECTION` type mirroring SSE; `isWsConnectionType` and `wsConnectionMethod` switch for `send`/`sendText`/`sendBinary`/`close`/`onOpen`/`onMessage`/`onClose`. |
| `kof-compiler/.../SemanticAnalyzer.java` | Trailing-block rewrite: `app.ws(path, lambda_no_params)` -> `app.ws(path, (ws: KofRuntime$WsConnection) -> body)`. Receiver-type dispatch falls through to `wsConnectionMethod`. |
| `kof-compiler/src/test/.../KofWebWsE2ETest.java` | 11 -> 16: `+echo_text`, `+multi_frame`, `+onClose_called_when_client_closes` (param-list removed from test body since upstream's Parser recognises only the unparenthesised form `{ code, reason -> ... }`), `+no_callback_keeps_ping_and_close` (regression), `+handler_exception_closes_connection_gracefully`. |

## What was discarded and why

- **The `CompilerDriver` locals-reorder fix.** Upstream `aaec9c8` ("fix: restaura descritores JVM + no-ops UI/Store perdidos no rebase") carries its own fix for the same bug, using `paramSlots[]` / `captureBase` / `captureSlot` instead of the simpler reorder I had locally. Including my fix on top of theirs would have undone a careful piece of upstream work. The fix is in upstream already.
- **The `parseLambdaBlock` helper in `Parser.java`.** Upstream's Parser grows inline support for trailing blocks with parameters (`looksLikeLambdaBlockParams()` and `parseLambdaBlockParams()`), which subsumes the helper I introduced. The same problem is solved two ways; upstream's inline version is more transparent in the call site.
- **The two-arg trailing-block form with parens** `{ (code, reason) -> ... }`. My local helper accepted that form; upstream's Parser only accepts the unparenthesised form `{ code, reason -> ... }`. The PR5 test was updated to match what upstream parses natively.

## What is not in this PR (known follow-up)

- `ws.onOpen` is wired through the compiler sugar (and accepted by `wsConnectionMethod`) but no runtime phase currently fires it. PR6 or a follow-up PR will pick a definition (post-101, first interaction, etc.).
- Binary message handler (`0x2`) is registered but discards the frame. The Kof side can call `ws.sendBinary(...)`; the server cannot yet echo binary. Future PR.
- `ws.ping(...)` from Kof compiles and works; tests cover the server->Kof PONG path only.

## Verification

```
mvn -pl kof-compiler -am test -Dtest='KofWebE2ETest,KofWebTlsTest,KofWebSseE2ETest,KofWebWsE2ETest,KofWsFrameTest'
→ Tests run: 45, Failures: 0, Errors: 0, Skipped: 0
→ BUILD SUCCESS

mvn -pl kof-compiler -am test (full suite)
→ 652 tests, 197 pre-existing Native backend failures on this host (unchanged).
```

## Caveat / status

The local fork `codex/pr4-ws-frames` still has the abandoned `23b7f02` (PR5-on-top-of-PR4) commit because it was force-pushed just before the upstream merged the older `1b39ed7`. That branch on the fork is now stale wrt upstream; cleaning it up is a separate task and should not be done without explicit confirmation.