### PR TITLE
docs: remove seção duplicada/desatualizada do bug 6 em known-bugs.md

### DIFF
--- a/docs/development/known-bugs.md
+++ b/docs/development/known-bugs.md
@@ -118,24 +118,6 @@
 
 ---
 
-### 6. Sufixo numérico MAIÚSCULO gera bytecode inválido
-
-- **Sintoma:** `42L` / `1.5F` compilam mas falham no load. Minúsculo
-  (`42l`, `1.5f`) funciona.
-- **Reprodução:**
-  ```kof
-  main() {
-      var x = 42L    // ClassFormatError
-      var y = 1.5F   // idem
-  }
-  ```
-- **Causa provável:** o lexer/lowering trata o sufixo maiúsculo como
-  identificador/errado. Deveria ser alias do minúsculo (ou rejeitar com
-  diagnostic claro).
-- **Arquivos:** `Lexer.java`, `Parser.java` (literais numéricos), `CompilerDriver.java`.
-
----
-
 ### 7. Argumento de tipo nullable em chamada genérica não parseia
 
 - **Sintoma:** `listOf<String?>()` → PARSE041 (Unexpected token `?`).
@@ -1047,7 +1029,7 @@ EXTERNA produz lixo
 
 ## Resolvidos nesta branch (referência)
 
-- `42l`/`1.5f` minúsculos funcionam (os maiúsculos são o Bug 6).
+- `42l`/`1.5f` minúsculos funcionam (maiúsculos também — ver Bug 6 abaixo).
 - `Long as Int` funciona (fix 01/09) — o FP→Int é o Bug 5.
 - Null-safety narrowing JVM (`s.length` pós-guard) — corrigido 02/09.
 - Concat `"str" + double` — corrigido 02/09.


### PR DESCRIPTION
## Summary
- O fix do bug 6 (`ba6cb159`, 03/09 — sufixo numérico maiúsculo `42L`/`1.5F`) adicionou a entrada em "Resolvidos nesta branch" mas esqueceu de remover a seção numerada original `### 6.` que ainda descrevia o bug como aberto.
- Removida a seção duplicada e ajustada a referência cruzada na seção "Resolvidos" (linha que citava "os maiúsculos são o Bug 6" como se ainda fosse um problema à parte).
- Sem mudança de código — o bug já está corrigido no `Lexer.readNumber` e coberto por `CoreRegressionE2ETest.uppercaseNumericSuffixes` (JVM+Native).

Fixes #40

## Test plan
- [x] Confirmado via `bin/kof run --target=jvm` que `42L`/`1.5F` compilam e executam corretamente na árvore atual.
- [x] Localizado o teste de regressão existente (`CoreRegressionE2ETest.uppercaseNumericSuffixes`) que cobre o caso.
- [x] `git diff` revisado — apenas remoção de texto duplicado/desatualizado em `docs/development/known-bugs.md`, nenhuma mudança de código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CpXesgsYTui1VradhzAF2