### PR TITLE
fix(kofjs): atribuição a parâmetro deixa de emitir `let` redeclarado (#43)

### DIFF
--- a/kof-compiler/src/main/java/dev/kof/compiler/js/JsMethodParser.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/js/JsMethodParser.java
@@ -100,18 +100,11 @@ public final class JsMethodParser {
     }
 
     List<String> parameterNames(MethodCtx ctx) {
-        if ("main".equals(ctx.methodName) && ctx.paramCount == 1) {
-            // The injected String[] parameter is not a source parameter.
-            return List.of();
-        }
+        // Fonte única: os mesmos slots que MethodCtx marca como já declarados
+        // (known-bugs #63). Assinatura e `declared` não podem divergir.
         List<String> names = new ArrayList<>();
-        int start = ctx.instanceMethod ? 1 : 0;
-        for (int i = start; i < ctx.localNames.size() && names.size() < ctx.paramCount; i++) {
-            if (ctx.captureSlots.contains(i)) continue;
-            String name = ctx.localNames.get(i);
-            if (name != null) {
-                names.add(name);
-            }
+        for (int slot : ctx.parameterSlots()) {
+            names.add(ctx.localNames.get(slot));
         }
         return names;
     }

--- a/kof-compiler/src/main/java/dev/kof/compiler/js/MethodCtx.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/js/MethodCtx.java
@@ -76,6 +76,35 @@ public final class MethodCtx {
             }
             localNames.put(lv.index(), uniqueName(JsTypeMapper.sanitizeName(lv.name())));
         }
+        // known-bugs #63: os PARÂMETROS já estão ligados pela assinatura da
+        // função JS, então o primeiro store num slot de parâmetro é uma
+        // atribuição, nunca uma declaração (`let a = ...` redeclara e o
+        // SyntaxError derruba o módulo inteiro). Deriva da MESMA fonte que
+        // monta a assinatura (parameterSlots), para que os dois não possam
+        // divergir.
+        declared.addAll(parameterSlots());
+    }
+
+    /**
+     * Slots ligados pela assinatura da função JS, na ordem. É a fonte única
+     * usada tanto para emitir a lista de parâmetros quanto para saber quais
+     * slots já estão declarados (known-bugs #63).
+     *
+     * <p>As capturas ficam de fora: em {@code invoke()} elas são locais
+     * copiados dos campos e precisam manter o próprio {@code let}.
+     */
+    List<Integer> parameterSlots() {
+        if ("main".equals(methodName) && paramCount == 1) {
+            // O parâmetro String[] injetado no main não é parâmetro de fonte.
+            return List.of();
+        }
+        List<Integer> slots = new ArrayList<>();
+        int start = instanceMethod ? 1 : 0;
+        for (int i = start; i < localNames.size() && slots.size() < paramCount; i++) {
+            if (captureSlots.contains(i)) continue;
+            if (localNames.get(i) != null) slots.add(i);
+        }
+        return slots;
     }
 
     String uniqueName(String base) {

--- a/kof-compiler/src/test/java/dev/kof/compiler/CoreRegressionE2ETest.java
+++ b/kof-compiler/src/test/java/dev/kof/compiler/CoreRegressionE2ETest.java
@@ -780,4 +780,78 @@ class CoreRegressionE2ETest {
                 }
                 """, "8\n12", tempDir, "lambda-returning-lambda");
     }
+
+    // known-bugs #63 / GitHub #43 — assigning to a PARAMETER emitted a `let`
+    // redeclaration in KofJS ("Variable 'a' has already been declared"), a
+    // parse error that killed the whole module. Parameters are already bound
+    // by the JS function signature, so the first store to a parameter slot is
+    // an assignment, never a declaration. JVM and the interpreter were correct.
+    @Test
+    void assignmentToParameterIsNotARedeclarationInJs(@TempDir Path tempDir) throws IOException {
+        runBoth("""
+                Int f(Int a) {
+                    a = 99
+                    return a
+                }
+                main() {
+                    println(f(1))
+                }
+                """, "99", tempDir, "param-assign");
+    }
+
+    // Same root cause, the remaining shapes: two stores to one parameter,
+    // compound assignment, an instance method (slot 0 is `this`) and a lambda
+    // (capture slots come before the real parameters).
+    @Test
+    void parameterReassignmentAcrossAllShapes(@TempDir Path tempDir) throws IOException {
+        runBoth("""
+                Int twice(Int a) {
+                    a = 1
+                    a = 2
+                    return a
+                }
+                Int compound(Int a) {
+                    a += 1
+                    return a
+                }
+                class C {
+                    Int m(Int a) {
+                        a = 7
+                        return a
+                    }
+                }
+                main() {
+                    println(twice(0))
+                    println(compound(5))
+                    var c = C()
+                    println(c.m(1))
+                    var g = (n: Int) -> {
+                        n = 3
+                        return n
+                    }
+                    println(g(1))
+                }
+                """, "2\n6\n7\n3", tempDir, "param-assign-shapes");
+    }
+
+    // The lambda case with a CAPTURE: in the synthetic invoke() the capture
+    // slots come before the real parameters, so the seeded parameter range has
+    // to account for them. The lambda reassigns its own parameter and only
+    // READS the capture (mutable-capture semantics is known-bugs #9 — kept out
+    // of this test on purpose).
+    @Test
+    void parameterReassignedInsideCapturingLambda(@TempDir Path tempDir) throws IOException {
+        runBoth("""
+                Int outer(Int base) {
+                    var add = (n: Int) -> {
+                        n = n + base
+                        return n
+                    }
+                    return add(1)
+                }
+                main() {
+                    println(outer(5))
+                }
+                """, "6", tempDir, "param-assign-capture");
+    }
 }


### PR DESCRIPTION
Fecha #43.

## O bug

`JsExpressionParser.storeLocalStatement` decidia entre declaração e atribuição pelo critério "primeiro store no slot" — o primeiro virava `let x = ...`. Correto para locais de verdade, errado para **parâmetros**, que já estão ligados pela assinatura da função JS:

```kof
Int f(Int a) {
    a = 99
    return a
}
```

```js
function f(a) {
    let a = 99;   // SyntaxError: Variable "a" has already been declared
    return a;
}
```

Por ser erro de *parse*, derrubava o **módulo inteiro** — não só a função afetada. JVM e interpretador sempre estiveram corretos; era divergência exclusiva do KofJS.

Atingia todas as formas: função top-level, duas atribuições ao mesmo parâmetro, compound (`a += 1`), método de classe e lambda.

## A correção

`MethodCtx` passa a semear `declared` com os slots dos parâmetros **antes** de o corpo ser parseado.

Os slots vêm de um `parameterSlots()` novo, extraído da lógica que `JsMethodParser.parameterNames` já usava para montar a assinatura. As duas passam a derivar da **mesma fonte**, então assinatura e `declared` não podem divergir — que era exatamente a classe de erro em questão.

As capturas ficam de fora de propósito: em `invoke()` elas não são parâmetros, e sim locais copiados dos campos, que precisam manter o próprio `let`. Verificado no JS gerado:

```js
invoke(n) {
    let base = this.base;   // captura — continua sendo declaração
    return ((n + base) | 0);
}
```

## Provas

3 testes novos em `CoreRegressionE2ETest`, todos compilando para JVM **e** KofJS e exigindo saída idêntica:

| Teste | Cobre |
|---|---|
| `assignmentToParameterIsNotARedeclarationInJs` | o caso mínimo |
| `parameterReassignmentAcrossAllShapes` | dois stores, compound, método de classe, lambda |
| `parameterReassignedInsideCapturingLambda` | slots de captura antes dos parâmetros reais |

Os três falhavam com `Variable "x" has already been declared` antes da correção.

## Verificação de regressão

As **38 classes de teste que exercitam o alvo JS** foram rodadas com e sem o fix:

| | Testes | Falhas |
|---|---|---|
| Sem o fix | 427 | 79 |
| Com o fix | 430 (+3 novos) | 79 |

O conjunto de métodos que falham é **idêntico** nos dois lados — zero regressões, zero testes que passaram a falhar. As 79 falhas são ambientais e pré-existentes: toolchain Native ausente no host (arm64/macOS não monta o assembly x86_64/Linux) e testes que dependem de banco.

`scripts/check_500.sh` continua vermelho apenas nos 4 arquivos que já estavam acima do limite (`NativeBackend`, `JsControlFlowParser`, `Parser`, `JvmRuntimeCallDescriptors`) — nenhum tocado aqui. Os arquivos alterados têm 157 e 114 linhas.

## Descoberto durante o trabalho (fora do escopo deste PR)

Parâmetros `Long`/`Double` ocupam 2 slots, e o backend JS assume 1 slot por parâmetro. Consequência, **independente desta correção** (reproduzida também antes dela):

```kof
Double useAll(Long a, Int b, Double c) { return c }
main() { println(useAll(1L, 2, 3.5)) }
```

JVM imprime `3.5`; KofJS imprime `undefined`. Resposta errada em silêncio, sem diagnóstico. Vai ser registrado em issue própria.
