### PR TITLE
fix(kofjs): parâmetro após um `Long`/`Double` deixa de sumir da assinatura (#47)

### DIFF
--- a/kof-compiler/src/main/java/dev/kof/compiler/js/JsMethodParser.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/js/JsMethodParser.java
@@ -122,12 +122,21 @@ public final class JsMethodParser {
             // The injected String[] parameter is not a source parameter.
             return List.of();
         }
+        // known-bugs #64 / GitHub #47: `Long` e `Double` ocupam DOIS slots, então
+        // os índices são ESPARSOS — em `f(Long a, Int b)` o mapa é {0:a, 2:b}.
+        // Percorrer `0..localNames.size()` parava antes do slot 2 e descartava
+        // `b` da assinatura (lido como `undefined`, sem diagnóstico). Percorre
+        // as chaves REAIS em ordem crescente.
+        List<Integer> ordered = new ArrayList<>(ctx.localNames.keySet());
+        java.util.Collections.sort(ordered);
         List<Integer> slots = new ArrayList<>();
         int start = ctx.instanceMethod ? 1 : 0;
-        for (int i = start; i < ctx.localNames.size() && slots.size() < ctx.paramCount; i++) {
-            if (ctx.captureSlots.contains(i)) continue;
-            if (ctx.localNames.get(i) != null) {
-                slots.add(i);
+        for (int slot : ordered) {
+            if (slots.size() == ctx.paramCount) break;
+            if (slot < start) continue;
+            if (ctx.captureSlots.contains(slot)) continue;
+            if (ctx.localNames.get(slot) != null) {
+                slots.add(slot);
             }
         }
         return slots;

--- a/kof-compiler/src/main/java/dev/kof/compiler/js/JsMethodParser.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/js/JsMethodParser.java
@@ -35,6 +35,9 @@ public final class JsMethodParser {
 
     List<JsIr.JsStatement> parseMethodBody(MethodCtx ctx) {
         this.lc.currentCtxOpsDump = ctx.ops;
+        for (int slot : parameterSlots(ctx)) {
+            ctx.declared.add(slot);
+        }
         int[] pos = {0};
         List<JsIr.JsStatement> body = flow.parseStatements(ctx, pos, Set.of(), new ArrayList<>());
         if (pos[0] < ctx.ops.size()) {
@@ -100,20 +103,34 @@ public final class JsMethodParser {
     }
 
     List<String> parameterNames(MethodCtx ctx) {
+        List<String> names = new ArrayList<>();
+        for (int slot : parameterSlots(ctx)) {
+            names.add(ctx.localNames.get(slot));
+        }
+        return names;
+    }
+
+    /**
+     * Slots dos parâmetros que viram a assinatura da função JS (exclui
+     * capturas de lambda, que ficam nos slots iniciais mas são locais
+     * comuns no corpo — e exclui o `String[] args` injetado de `main`,
+     * que não é parâmetro de origem). Fonte única para `parameterNames`
+     * (nomes da assinatura) e `parseMethodBody` (semeadura de `declared`).
+     */
+    List<Integer> parameterSlots(MethodCtx ctx) {
         if ("main".equals(ctx.methodName) && ctx.paramCount == 1) {
             // The injected String[] parameter is not a source parameter.
             return List.of();
         }
-        List<String> names = new ArrayList<>();
+        List<Integer> slots = new ArrayList<>();
         int start = ctx.instanceMethod ? 1 : 0;
-        for (int i = start; i < ctx.localNames.size() && names.size() < ctx.paramCount; i++) {
+        for (int i = start; i < ctx.localNames.size() && slots.size() < ctx.paramCount; i++) {
             if (ctx.captureSlots.contains(i)) continue;
-            String name = ctx.localNames.get(i);
-            if (name != null) {
-                names.add(name);
+            if (ctx.localNames.get(i) != null) {
+                slots.add(i);
             }
         }
-        return names;
+        return slots;
     }
 
 

--- a/kof-compiler/src/test/java/dev/kof/compiler/CoreRegressionE2ETest.java
+++ b/kof-compiler/src/test/java/dev/kof/compiler/CoreRegressionE2ETest.java
@@ -838,4 +838,72 @@ class CoreRegressionE2ETest {
                 }
                 """, "8\n12", tempDir, "lambda-returning-lambda");
     }
+
+    // known-bugs #64 / GitHub #47 — `Long` and `Double` occupy TWO slots, but
+    // the JS signature was built assuming one slot per parameter, so every
+    // parameter AFTER a wide one was dropped from the emitted signature and
+    // read back as `undefined` (silently wrong, no diagnostic). JVM was
+    // correct. A wide parameter in LAST position never triggered it.
+    @Test
+    void parameterAfterALongIsNotDroppedFromTheJsSignature(@TempDir Path tempDir) throws IOException {
+        runBoth("""
+                Int after(Long a, Int b) {
+                    return b
+                }
+                main() {
+                    println(after(1L, 42))
+                }
+                """, "42", tempDir, "wide-long-then-int");
+    }
+
+    @Test
+    void parameterAfterADoubleIsNotDroppedFromTheJsSignature(@TempDir Path tempDir) throws IOException {
+        runBoth("""
+                Int after(Double a, Int b) {
+                    return b
+                }
+                main() {
+                    println(after(1.5, 42))
+                }
+                """, "42", tempDir, "wide-double-then-int");
+    }
+
+    // Every parameter of a mixed-width signature must survive, including a
+    // narrow one sandwiched between two wide ones.
+    @Test
+    void mixedWidthParametersAllSurviveInJs(@TempDir Path tempDir) throws IOException {
+        runBoth("""
+                Double all(Long a, Int b, Double c) {
+                    return c
+                }
+                Int middle(Long a, Int b, Double c) {
+                    return b
+                }
+                Long first(Long a, Int b, Double c) {
+                    return a
+                }
+                main() {
+                    println(all(1L, 2, 3.5))
+                    println(middle(1L, 2, 3.5))
+                    println(first(1L, 2, 3.5))
+                }
+                """, "3.5\n2\n1", tempDir, "wide-mixed");
+    }
+
+    // The wide parameter belongs to an instance method (slot 0 is `this`), so
+    // the slot walk has to stay correct with the receiver in front.
+    @Test
+    void wideParametersInInstanceMethodKeepAllArgumentsInJs(@TempDir Path tempDir) throws IOException {
+        runBoth("""
+                class Calc {
+                    Int pick(Long a, Int b) {
+                        return b
+                    }
+                }
+                main() {
+                    var c = Calc()
+                    println(c.pick(1L, 42))
+                }
+                """, "42", tempDir, "wide-instance-method");
+    }
 }

--- a/kof-compiler/src/test/java/dev/kof/compiler/CoreRegressionE2ETest.java
+++ b/kof-compiler/src/test/java/dev/kof/compiler/CoreRegressionE2ETest.java
@@ -357,6 +357,64 @@ class CoreRegressionE2ETest {
                 """, "hello Mel\nhello world\n15\n12", tempDir, "b8");
     }
 
+    @Test
+    void assignmentToParameterDoesNotRedeclareInJs(@TempDir Path tempDir) throws IOException {
+        runBoth("""
+                Int f(Int a) {
+                    a = 99
+                    return a
+                }
+
+                main() {
+                    println(f(1))
+                }
+                """, "99", tempDir, "param-reassign-simple");
+    }
+
+    @Test
+    void compoundAssignmentToParameterDoesNotRedeclareInJs(@TempDir Path tempDir) throws IOException {
+        runBoth("""
+                Int f(Int a) {
+                    a += 5
+                    return a
+                }
+
+                main() {
+                    println(f(1))
+                }
+                """, "6", tempDir, "param-reassign-compound");
+    }
+
+    @Test
+    void classMethodParameterReassignmentDoesNotRedeclareInJs(@TempDir Path tempDir) throws IOException {
+        runBoth("""
+                class Calc {
+                    Int bump(Int n) {
+                        n = n + 1
+                        return n
+                    }
+                }
+
+                main() {
+                    var c = Calc()
+                    println(c.bump(6))
+                }
+                """, "7", tempDir, "param-reassign-method");
+    }
+
+    @Test
+    void lambdaParameterReassignmentDoesNotRedeclareInJs(@TempDir Path tempDir) throws IOException {
+        runBoth("""
+                main() {
+                    var f = (n: Int) -> {
+                        n = 3
+                        return n
+                    }
+                    println(f(0))
+                }
+                """, "3", tempDir, "param-reassign-lambda");
+    }
+
     // F2 — main(args: List<String>) receives the program arguments (JVM)
     @Test
     void mainArgsList(@TempDir Path tempDir) throws IOException {


### PR DESCRIPTION
Fecha #47.

> **Empilhado sobre o #45** — toca o mesmo método (`parameterSlots`), então parte do `parametro-let` para evitar conflito. **Mergear o #45 primeiro**; depois disso o diff aqui fica só nos 2 arquivos deste commit.

## O bug

`Long` e `Double` ocupam **dois slots**, mas a montagem da assinatura JS assumia um slot por parâmetro:

```java
for (int i = start; i < ctx.localNames.size() && slots.size() < ctx.paramCount; i++) {
```

Com um parâmetro largo os índices ficam **esparsos**: em `f(Long a, Int b)` o mapa é `{0:a, 2:b}`, e `localNames.size()` é `2` — o laço vai até `i = 1` e para antes de alcançar o slot `2`.

Todo parâmetro depois de um `Long`/`Double` era descartado da assinatura emitida e lido como `undefined`. **Sem erro, sem diagnóstico** — resposta errada em silêncio:

```kof
Int after(Long a, Int b) { return b }
main() { println(after(1L, 42)) }
```

JVM `42` · KofJS **`undefined`**, com `function after(a) { return b; }`.

## A correção

Percorre as chaves reais de slot em ordem crescente, em vez de assumir `0..size`.

## Matriz coberta

| Caso | Antes | Depois |
|---|---|---|
| `after(Long a, Int b)` | `undefined` | `42` |
| `after(Double a, Int b)` | `undefined` | `42` |
| largura mista, lendo as 3 posições | `undefined` | `3.5` / `2` / `1` |
| método de instância (slot 0 = `this`) | `undefined` | `42` |

Com o parâmetro largo em **último** lugar o defeito nunca aparecia, porque o truncamento não chegava a descartar nada — por isso passou despercebido.

## Provas

4 testes novos em `CoreRegressionE2ETest`, todos compilando para JVM **e** KofJS e exigindo saída idêntica. Os quatro falhavam com `expected: <42> but was: <undefined>`.

## Verificação de regressão

As 38 classes de teste que exercitam o alvo JS, com e sem o fix:

| | Testes | Falhas |
|---|---|---|
| Sem o fix | 431 | 79 |
| Com o fix | 435 (+4 novos) | 79 |

Conjunto de métodos que falham **idêntico** nos dois lados — zero regressões. As 79 são ambientais e pré-existentes: toolchain Native ausente no host (arm64/macOS não monta assembly x86_64/Linux) e testes que dependem de banco.

## Nota

A entrada correspondente no `known-bugs.md` vai no #44, onde a numeração das entradas novas (62, 63) já está — evita conflito no mesmo arquivo.
