### PR TITLE
fix(native): sintetizar hashCode() para records no backend nativo (#55)

### DIFF
--- a/docs/development/conformance-matrix.md
+++ b/docs/development/conformance-matrix.md
@@ -38,7 +38,7 @@
 | switch-expression `case ->` | `three` | DONE | DONE | DONE | DONE | `switchexpr` |
 | for-in + break/continue | `4` | DONE | DONE | DONE | DONE | `breakcont` |
 | record `==` conteúdo + toString + accessor | `true` / `P[x=1, y=2]` / `1` | DONE | DONE | DONE | DONE | `record` |
-| record `hashCode()` igual | `true` | DONE | PARTIAL (bug 42: ld P_hashCode) | DONE | DONE (bug 42 JS corrigido `1ecfb3d`) | `recordhash` |
+| record `hashCode()` igual | `true` | DONE | DONE (bug 42 Native corrigido) | DONE | DONE (bug 42 JS corrigido `1ecfb3d`) | `recordhash` |
 | lambda filter/map/reduce | `90` | DONE | DONE | DONE | DONE | `lambdachain` |
 | lambda captura mutável | `3` | DONE | DONE | DONE | DONE | `lambdacapture` |
 | array 2D/length | `60` / `3` | DONE | DONE | DONE | DONE | `array2d` |

--- a/docs/development/known-bugs.md
+++ b/docs/development/known-bugs.md
@@ -799,13 +799,14 @@ EXTERNA produz lixo
 - **Prova/repro:** sweep cross-target 07/09 (casos `static-field` / `static-field-plus-eq`), Native x86_64.
 - **Correção (lane Native, regra 6):** emitir `KofGetStatic`/`KofPutStatic` em `nat/NativeBackend` + `nat/NativeRiscvCrossEmit` (86-87) com offset real de campo estático (residir em segmento de dados, não em stack) — e remover os stubs silenciosos (R6).
 
-### 42. `hashCode()` de record ausente no JS e no Native — ✅ CORRIGIDO 07/09 (metade JS; metade Native segue ABERTA)
+### 42. `hashCode()` de record ausente no JS e no Native — ✅ CORRIGIDO (JS `1ecfb3d` + Native `buildRecordHashCodeMethod`)
 
 - **Sintoma:** `record P(Int x, Int y)` + `a.hashCode() == b.hashCode()`: JVM/interpretador → `true`; **JS** → `TypeError: a.hashCode is not a function` (exit 1); **Native** → `ld: undefined reference to 'P_hashCode'` (fail de link, exit 1).
-- **Causa raiz:** o runtime de record no JS/Native não emite o método `hashCode` (o JVM gera `hashCode` no `KofRuntime`). `equals`/`toString` existem nos 3; `hashCode` não.
-- **Corrigido 07/09 (metade JS, `1ecfb3d`):** `JsClassEmitter` emite `hashCode()` sintético de record (espelhando `JvmRecordEmitter`) + `kof_hashCode` no runtime JS. Verificado 08/09: JS roda `true` — exclusão `js` removida de `ConformanceMatrixTest.recordhash`. **Metade Native segue ABERTA** (`ld: undefined reference to 'P_hashCode'` — lane Native, `nat/` EM CURSO no REFACTOR-500).
-- **Prova/repro:** sweep cross-target 07/09 (caso `record-eq-hash`); `ConformanceMatrixTest.recordhash` (JVM/Script/JS verdes, Native excluído).
-- **Nota:** `a == b` (igualdade de conteúdo) e `println(a)` (`P[x=1, y=2]`) **têm** paridade nos 3 — só o `hashCode()` diverge.
+- **Causa raiz:** o runtime de record no JS/Native não emitia o método `hashCode` (o JVM gera `hashCode` no `JvmRecordEmitter`). `equals`/`toString` existiam nos 3; `hashCode` não.
+- **Corrigido (JS, `1ecfb3d`):** `JsClassEmitter` emite `hashCode()` sintético de record + `kof_hashCode` no runtime JS.
+- **Corrigido (Native):** `CompilerRecordSupport.buildRecordHashCodeMethod` sintetiza `hashCode()` acumulando `31 * h + campo` no IR para Native (`lowerRecord`), gerando o símbolo `P_hashCode`. Exclusão de `native` removida de `ConformanceMatrixTest.recordhash`.
+- **Prova/repro:** `ConformanceMatrixTest.recordhash` (verde nos 4 targets: JVM, Script, JS e Native).
+- **Nota:** `a == b` (igualdade de conteúdo), `println(a)` (`P[x=1, y=2]`) e `a.hashCode() == b.hashCode()` agora têm paridade nos 3 targets.
 
 ### 43. String no Native conta bytes UTF-8, JVM conta code units — ✅ CORRIGIDO 07/09 (lane Native) UTF-16 — ABERTO (lane Native; cf. STR001)
 

--- a/kof-compiler/src/main/java/dev/kof/compiler/CompilerClassLowering.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/CompilerClassLowering.java
@@ -110,6 +110,7 @@ public final class CompilerClassLowering {
                 || driver.target == Target.NATIVE_AARCH64) {
             methods.add(CompilerRecordSupport.buildRecordToStringMethod(driver, internalName, rec, fields, typeParams));
             methods.add(CompilerRecordSupport.buildRecordEqualsMethod(driver, internalName, fields, typeParams));
+            methods.add(CompilerRecordSupport.buildRecordHashCodeMethod(driver, internalName, fields, typeParams));
         }
         return new IRClass(internalName, superName, ifaces, access, fields, methods, List.of(), null,
                 typeId, CompilerAnnotations.lowerAnnotations(driver, rec.annotations()));

--- a/kof-compiler/src/main/java/dev/kof/compiler/CompilerRecordSupport.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/CompilerRecordSupport.java
@@ -91,6 +91,29 @@ public final class CompilerRecordSupport {
                 List.of(), List.of(new IRBasicBlock(0, ops)), locals);
     }
 
+    /**
+     * hashCode() nativo de record: 31 * h + campo (bug 42 native).
+     */
+    static IRMethod buildRecordHashCodeMethod(CompilerDriver driver, String internalName,
+                                              List<IRField> fields,
+                                              List<String> typeParams) {
+        Type ownerType = CompilerTypes.ownerTypeFromInternal(internalName, driver.semanticAnalyzer);
+        List<KofOperation> ops = new ArrayList<>();
+        List<IRLocalVariable> locals = new ArrayList<>();
+        locals.add(new IRLocalVariable(0, "this", ownerType));
+        ops.add(new KofLoadLiteral(Type.PrimitiveType.INT, 1));
+        for (IRField f : fields) {
+            ops.add(new KofLoadLiteral(Type.PrimitiveType.INT, 31));
+            ops.add(new KofBinary(KofBinaryOp.MUL, Type.PrimitiveType.INT));
+            ops.add(new KofLoadLocal(ownerType, 0));
+            ops.add(new KofLoadField(ownerType, f.name(), f.type()));
+            ops.add(new KofBinary(KofBinaryOp.ADD, Type.PrimitiveType.INT));
+        }
+        ops.add(new KofReturn(Type.PrimitiveType.INT));
+        return new IRMethod("hashCode", Type.PrimitiveType.INT, List.of(), AccessFlags.PUBLIC,
+                List.of(), List.of(new IRBasicBlock(0, ops)), locals);
+    }
+
     static IRMethod generateRecordConstructor(CompilerDriver driver, RecordDeclarationNode rec,
                                   String owner) {
         List<String> typeParams = rec.typeParameters() == null ? List.of() : rec.typeParameters();

--- a/kof-compiler/src/test/java/dev/kof/compiler/ConformanceMatrixTest.java
+++ b/kof-compiler/src/test/java/dev/kof/compiler/ConformanceMatrixTest.java
@@ -376,8 +376,8 @@ class ConformanceMatrixTest {
                     println(a.x())
                 }
                 """, "true\nP[x=1, y=2]\n1", Set.of(), tempDir);
-        // PARTIAL: bug 42 (hashCode ausente no Native: ld P_hashCode).
         // Metade JS CORRIGIDA 07/09 (verificado 08/09: JS roda 'true').
+        // Metade Native CORRIGIDA (buildRecordHashCodeMethod em CompilerRecordSupport).
         matrix("recordhash", """
                 record P(Int x, Int y)
                 main() {
@@ -385,7 +385,7 @@ class ConformanceMatrixTest {
                     var b = P(1,2)
                     println(a.hashCode() == b.hashCode())
                 }
-                """, "true", Set.of("native"), tempDir);
+                """, "true", Set.of(), tempDir);
         // PARTIAL: bug 41 (Native stub vazio KofGetStatic/KofPutStatic → lixo).
         matrix("staticfield", """
                 class Counter {


### PR DESCRIPTION
### O que foi feito?

Este PR resolve a metade Native do **Bug 42**, sintetizando o método `hashCode()` para declarações de `record` no backend nativo, eliminando a falha de link `ld: undefined reference to P_hashCode`.

### Detalhes das Alterações:

1. **`CompilerRecordSupport.java`:**
   - Adicionado o método auxiliar `buildRecordHashCodeMethod(CompilerDriver, String, List<IRField>, List<String>)` que monta o `IRMethod` de `hashCode()` acumulando `31 * h + campo` sobre os componentes do record.
2. **`CompilerClassLowering.java`:**
   - Registrada a emissão de `buildRecordHashCodeMethod` junto a `toString` e `equals` para targets nativos (`Target.NATIVE` e arquiteturas derivadas).
3. **`ConformanceMatrixTest.java` e `docs/development/conformance-matrix.md`:**
   - Removida a exclusão `native` no caso de teste `recordhash`.
   - Atualizada a matriz de conformidade e `known-bugs.md` documentando a paridade de `record.hashCode()` entre JVM, Script, JS e Native.

### Validação e Testes:

- `mvn test -Dtest=ConformanceMatrixDocTest,ConformanceMatrixTest`: 12/12 testes passando (`BUILD SUCCESS`).
- `CoreRegressionE2ETest`: suíte de regressão verde.
- Verificação de limites de linhas de classes do projeto ($\le 500$ linhas):
  - `CompilerClassLowering.java`: 430 linhas
  - `CompilerRecordSupport.java`: 190 linhas

Closes #55
