### PR TITLE
docs: add GitHub issue form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,93 @@
+name: Bug report
+description: Report a bug in the Kof language, compiler, or standard library
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please provide a minimal
+        reproduction so we can confirm it without rediscovering the problem.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: target
+    attributes:
+      label: Target
+      description: Which backend does this affect?
+      multiple: true
+      options:
+        - JVM
+        - Native
+        - JS
+        - Script / interpreter
+        - Unknown / all
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Kof version
+      description: Output of `kof --version` (e.g. 0.3.2-beta).
+      placeholder: "0.3.2-beta"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      description: OS and architecture (e.g. macOS 15 arm64, Ubuntu 24.04 x86_64).
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: The smallest Kof snippet that triggers the bug.
+      render: kof
+    validations:
+      required: true
+
+  - type: input
+    id: command
+    attributes:
+      label: Command used
+      description: The exact command you ran.
+      placeholder: "kof run --target=jvm repro.kof"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include the full error output or stack trace.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: I reproduced this against the latest build.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / support
+    url: https://github.com/KofLang/Kof4j/discussions
+    about: Ask usage questions and get help in Discussions instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,41 @@
+name: Documentation
+description: Report a problem with the documentation or request new docs
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Affected page or file
+      description: URL or path in the repo (e.g. docs/compiler-architecture.md).
+    validations:
+      required: true
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Type of issue
+      options:
+        - Incorrect / outdated information
+        - Missing information
+        - Unclear explanation
+        - Broken link or example
+        - New documentation needed
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is wrong or missing?
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested change
+      description: How would you fix or improve it?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: Feature request
+description: Propose a new feature or improvement for Kof
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve? What are you trying to do today that is hard or impossible?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the feature. Include example syntax or API if relevant.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the project does this affect?
+      multiple: true
+      options:
+        - Language / syntax
+        - Compiler
+        - Standard library
+        - Tooling (CLI, LSP, debugger)
+        - Documentation
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about and why you rejected them.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true


### PR DESCRIPTION
## What

Adds structured issue forms under `.github/ISSUE_TEMPLATE/`:

- **documentation.yml** — affected page, issue type, description, suggested change. Label: `documentation`
- **config.yml** — disables blank issues and links usage questions to Discussions

## Why

Standardize incoming reports so bugs come with a reproduction and target, and route support questions to Discussions.

## Notes

- Labels `bug`, `enhancement`, `documentation` are expected to exist in the repo.
- YAML validated locally.