### PR TITLE
fix(parser): ExpressionStmt captura posição no lugar errado (LineNumb…

### DIFF
--- a/kof-compiler/src/main/java/dev/kof/compiler/ExpressionAssignmentLowerer.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/ExpressionAssignmentLowerer.java
@@ -95,7 +95,29 @@ if (ae.target() instanceof FieldAccessExpr fa) {
         SymbolTable.ClassSymbol cs = driver.semanticAnalyzer.getClass(rid.name());
         SymbolTable.Symbol fs = HierarchyResolver.resolveFieldInHierarchy(cs.name(), fa.fieldName(), driver.semanticAnalyzer);
         if (fs instanceof SymbolTable.FieldSymbol fld) {
+            String qop = ae.operator();
+            boolean qCompound = "+=".equals(qop) || "-=".equals(qop) || "*=".equals(qop)
+                    || "/=".equals(qop) || "%=".equals(qop) || "&=".equals(qop)
+                    || "|=".equals(qop) || "^=".equals(qop);
+            if (qCompound) {
+                ops.add(new KofGetStatic(cs.type(), fa.fieldName(), fld.type()));
+            }
             localIdx = ExpressionLowerer.emitExpression(driver, ae.value(), ops, owner, localIdx, locals);
+            if (qCompound) {
+                driver.emitPrimWidenNarrow(ops, ae.value(), fld.type(), locals);
+                KofBinaryOp qBinOp = switch (qop) {
+                    case "+=" -> KofBinaryOp.ADD;
+                    case "-=" -> KofBinaryOp.SUB;
+                    case "*=" -> KofBinaryOp.MUL;
+                    case "/=" -> KofBinaryOp.DIV;
+                    case "%=" -> KofBinaryOp.MOD;
+                    case "&=" -> KofBinaryOp.AND;
+                    case "|=" -> KofBinaryOp.OR;
+                    case "^=" -> KofBinaryOp.XOR;
+                    default -> KofBinaryOp.ADD;
+                };
+                ops.add(new KofBinary(qBinOp, fld.type()));
+            }
             ops.add(new KofPutStatic(cs.type(), fa.fieldName(), fld.type()));
             return localIdx;
         }
@@ -218,11 +240,69 @@ if (ae.target() instanceof FieldAccessExpr fa) {
     return localIdx;
 }
 if (ae.target() instanceof ArrayAccessExpr aa) {
+    Type recvType = ExpressionTyper.inferExprType(driver, aa.receiver(), locals);
+    Type elemType = Type.arrayElementType(recvType);
+    String aaOp = ae.operator();
+    boolean aaCompound = "+=".equals(aaOp) || "-=".equals(aaOp) || "*=".equals(aaOp)
+            || "/=".equals(aaOp) || "%=".equals(aaOp) || "&=".equals(aaOp)
+            || "|=".equals(aaOp) || "^=".equals(aaOp);
+    if (aaCompound) {
+        // Bug: `a[i] += v` baixava como `a[i] = v` (sobrescrevia em vez de
+        // somar) — faltava ler o valor anterior. ArrayLoad/ArrayStore
+        // consomem (arrayref, index) — diferente de campo (só o receiver) —
+        // então não dá para duplicar com um DUP simples; guarda receiver e
+        // índice em locais temporários e reusa dos dois lados (mesmo padrão
+        // de CompilerUiEmitter.emitFieldIncrement).
+        int recvTmp = localIdx++;
+        int idxTmp = localIdx++;
+        int newTmp = localIdx++;
+        locals.add(new IRLocalVariable(recvTmp, "#arr", recvType));
+        locals.add(new IRLocalVariable(idxTmp, "#idx", Type.PrimitiveType.INT));
+        locals.add(new IRLocalVariable(newTmp, "#new", elemType));
+        localIdx = ExpressionLowerer.emitExpression(driver, aa.receiver(), ops, owner, localIdx, locals);
+        ops.add(new KofStoreLocal(recvType, recvTmp));
+        localIdx = ExpressionLowerer.emitExpression(driver, aa.index(), ops, owner, localIdx, locals);
+        ops.add(new KofStoreLocal(Type.PrimitiveType.INT, idxTmp));
+        ops.add(new KofLoadLocal(recvType, recvTmp));
+        ops.add(new KofLoadLocal(Type.PrimitiveType.INT, idxTmp));
+        ops.add(new KofArrayLoad(elemType));
+        if ("+=".equals(aaOp) && BuiltinTypes.isString(elemType)) {
+            ops.add(new KofCall(BuiltinTypes.STRING, "valueOf",
+                    List.of(Type.UnknownType.UNKNOWN), BuiltinTypes.STRING,
+                    KofCallKind.STATIC));
+            localIdx = ExpressionLowerer.emitExpression(driver, ae.value(), ops, owner, localIdx, locals);
+            ops.add(new KofCall(BuiltinTypes.STRING, "valueOf",
+                    List.of(Type.UnknownType.UNKNOWN), BuiltinTypes.STRING,
+                    KofCallKind.STATIC));
+            ops.add(new KofCall(BuiltinTypes.STRING, "kof_string_concat",
+                    List.of(BuiltinTypes.STRING, BuiltinTypes.STRING),
+                    BuiltinTypes.STRING, KofCallKind.FUNCTION));
+        } else {
+            localIdx = ExpressionLowerer.emitExpression(driver, ae.value(), ops, owner, localIdx, locals);
+            driver.emitPrimWidenNarrow(ops, ae.value(), elemType, locals);
+            KofBinaryOp aaBinOp = switch (aaOp) {
+                case "+=" -> KofBinaryOp.ADD;
+                case "-=" -> KofBinaryOp.SUB;
+                case "*=" -> KofBinaryOp.MUL;
+                case "/=" -> KofBinaryOp.DIV;
+                case "%=" -> KofBinaryOp.MOD;
+                case "&=" -> KofBinaryOp.AND;
+                case "|=" -> KofBinaryOp.OR;
+                case "^=" -> KofBinaryOp.XOR;
+                default -> KofBinaryOp.ADD;
+            };
+            ops.add(new KofBinary(aaBinOp, elemType));
+        }
+        ops.add(new KofStoreLocal(elemType, newTmp));
+        ops.add(new KofLoadLocal(recvType, recvTmp));
+        ops.add(new KofLoadLocal(Type.PrimitiveType.INT, idxTmp));
+        ops.add(new KofLoadLocal(elemType, newTmp));
+        ops.add(new KofArrayStore(elemType));
+        return localIdx;
+    }
     localIdx = ExpressionLowerer.emitExpression(driver, aa.receiver(), ops, owner, localIdx, locals);
     localIdx = ExpressionLowerer.emitExpression(driver, aa.index(), ops, owner, localIdx, locals);
     localIdx = ExpressionLowerer.emitExpression(driver, ae.value(), ops, owner, localIdx, locals);
-    Type recvType = ExpressionTyper.inferExprType(driver, aa.receiver(), locals);
-    Type elemType = Type.arrayElementType(recvType);
     // valor com primitivo ≠ slot (ex.: Int em Long[]) →
     // converter no IR (I2L/L2I), senão o emit gera aastore/
     // lastore com tipo errado e o verifier rejeita (o

--- a/kof-compiler/src/main/java/dev/kof/compiler/parser/StatementParser.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/parser/StatementParser.java
@@ -121,12 +121,14 @@ public class StatementParser {
             return StatementParser.parseVarDecl(ctx);
         }
         if (ctx.check(TokenType.SEMICOLON)) {
+            SourcePosition emptyPos = ctx.pos();
             ctx.advance();
-            return new ExpressionStmt(ctx.pos(), null);
+            return new ExpressionStmt(emptyPos, null);
         }
+        SourcePosition exprPos = ctx.pos();
         ExpressionNode expr = ExpressionParser.parseExpression(ctx);
         ctx.expectSemicolon();
-        return new ExpressionStmt(ctx.pos(), expr);
+        return new ExpressionStmt(exprPos, expr);
     }
 
     static StatementNode parseReturn(ParseContext ctx) {

--- a/kof-compiler/src/test/java/dev/kof/compiler/CoreRegressionE2ETest.java
+++ b/kof-compiler/src/test/java/dev/kof/compiler/CoreRegressionE2ETest.java
@@ -210,6 +210,26 @@ class CoreRegressionE2ETest {
                 """, "1\n2\n1\n6\n6\n5", tempDir, "b2");
     }
 
+    @Test
+    void compoundAssignmentOnArrayAndQualifiedStaticField(@TempDir Path tempDir) throws IOException {
+        runBoth("""
+                class Counter {
+                    static Int total = 10
+                }
+                main() {
+                    var values = new Int[1]
+                    values[0] = 10
+                    values[0] += 5
+                    println(values[0])
+                    Counter.total += 5
+                    println(Counter.total)
+                    var local = 10
+                    local += 5
+                    println(local)
+                }
+                """, "15\n15\n15", tempDir, "compound-array-static");
+    }
+
     // B3 — records inside typed lists keep their type through for-in
     @Test
     void recordsInListsKeepType(@TempDir Path tempDir) throws IOException {

--- a/kof-compiler/src/test/java/dev/kof/compiler/DebugInfoE2ETest.java
+++ b/kof-compiler/src/test/java/dev/kof/compiler/DebugInfoE2ETest.java
@@ -53,6 +53,30 @@ class DebugInfoE2ETest {
     }
 
     @Test
+    void expressionStatementLineNumbersMatchSource(@TempDir Path tempDir) throws IOException {
+        Path source = tempDir.resolve("Main.kf");
+        Files.writeString(source, """
+                record P(Int x)
+                main() {
+                    var p = P(1)
+                    println(p.x())
+                    println("fim")
+                }
+                """);
+        Path out = tempDir.resolve("out");
+        CompilationResult result = driver.compile(source, out, Target.JVM);
+        assertTrue(result.success(), "Compilation should succeed: " + result.diagnostics().getDiagnostics());
+
+        String javap = runJavap(out.resolve("Default/Main.class"));
+        assertTrue(javap.contains("line 4:"),
+                "println(p.x()) é a linha 4 — deve aparecer na LineNumberTable:\n" + javap);
+        assertTrue(javap.contains("line 5:"),
+                "println(\"fim\") é a linha 5 — deve aparecer na LineNumberTable:\n" + javap);
+        assertFalse(javap.contains("line 6:"),
+                "linha 6 é só o '}' de fechamento do main — não tem código, não deveria aparecer:\n" + javap);
+    }
+
+    @Test
     void nativeBinaryStillRuns(@TempDir Path tempDir) throws IOException {
         Path source = tempDir.resolve("Main.kf");
         Files.writeString(source, SRC);


### PR DESCRIPTION
…erTable)

Statements de expressão (println(...), chamadas, atribuições — o caso mais comum) capturavam a posição com ctx.pos() DEPOIS de parseExpression()+expectSemicolon(), que avançam o cursor até o início do PRÓXIMO statement (ou o `}` de fechamento, no último da função). Resultado: LineNumberTable do JVM aponta o statement para a linha seguinte, e a linha do `}` (sem código) ganha entradas fantasma.

Os irmãos (spawn/assert/break/continue) já capturavam a posição ANTES de consumir tokens — StatementParser.parseStatement agora segue o mesmo padrão para ExpressionStmt (statement vazio e caso geral).