### PR TITLE
fix(js): preservar operandos da pilha em if/switch-expressions (#69)

### DIFF
--- a/docs/development/conformance-matrix.md
+++ b/docs/development/conformance-matrix.md
@@ -36,11 +36,11 @@
 | set dedup/contains | `3` / `true` / `false` | DONE | DONE | DONE | DONE | `setdedup` |
 | if-expression aninhada | `small` | DONE | DONE | DONE | DONE | `nestedif` |
 | switch-expression `case ->` | `three` | DONE | DONE | DONE | DONE | `switchexpr` |
-| if-expr heterogêneo Int/String (issue #57) | `1` | DONE | DONE | DONE | PARTIAL (underflow KofJS §69) | `ifexpr-heterogeneous-direct` |
-| switch-expr heterogêneo Int/String (issue #57) | `1` | DONE | DONE | DONE | PARTIAL (underflow KofJS §69) | `switchexpr-heterogeneous-direct` |
-| if-expr heterogêneo Int/Long (§70, crash de join) | `1` | DONE | DONE | DONE | PARTIAL (underflow KofJS §69) | `ifexpr-intlong-direct` |
-| if-expr heterogêneo Long/Double (§70) | `2` | DONE | DONE | DONE | PARTIAL (underflow KofJS §69) | `ifexpr-longdouble-direct` |
-| if-expr heterogêneo Int/null (§70) | `1` | DONE | DONE | DONE | PARTIAL (underflow KofJS §69) | `ifexpr-intnull-direct` |
+| if-expr heterogêneo Int/String (issue #57) | `1` | DONE | DONE | DONE | DONE (bug 69 corrigido) | `ifexpr-heterogeneous-direct` |
+| switch-expr heterogêneo Int/String (issue #57) | `1` | DONE | DONE | DONE | DONE (bug 69 corrigido) | `switchexpr-heterogeneous-direct` |
+| if-expr heterogêneo Int/Long (§70, crash de join) | `1` | DONE | DONE | DONE | DONE (bug 69 corrigido) | `ifexpr-intlong-direct` |
+| if-expr heterogêneo Long/Double (§70) | `2` | DONE | DONE | DONE | DONE (bug 69 corrigido) | `ifexpr-longdouble-direct` |
+| if-expr heterogêneo Int/null (§70) | `1` | DONE | DONE | DONE | DONE (bug 69 corrigido) | `ifexpr-intnull-direct` |
 | for-in + break/continue | `4` | DONE | DONE | DONE | DONE | `breakcont` |
 | record `==` conteúdo + toString + accessor | `true` / `P[x=1, y=2]` / `1` | DONE | DONE | DONE | DONE | `record` |
 | record `hashCode()` igual | `true` | DONE | DONE (bug 42 Native corrigido) | DONE | DONE (bug 42 JS corrigido `1ecfb3d`) | `recordhash` |

--- a/docs/development/known-bugs.md
+++ b/docs/development/known-bugs.md
@@ -1295,16 +1295,26 @@ EXTERNA produz lixo — ✅ CORRIGIDO (teste `NativeE2ETest.nativeLambdaMutableC
   backend (`frame crash ... COMPUTE_FRAMES AIOOBE`, causa distinta:
   slot-size 1 vs 2 no join) — ver 70.
 
-### 69. KofJS: if heterogêneo → `expression stack underflow` (COMP002) — ABERTO (pré-existente, causa no backend JS)
+### 69. KofJS: if heterogêneo → `expression stack underflow` (COMP002) (issue #69) — ✅ CORRIGIDO 09/09
 
 - **Sintoma:** o MESMO programa da issue #57 (`println(if (s == "") 1 else "s")`)
   no target JS: `Internal compiler error: KofJS: expression stack underflow`
   (COMP002), em vez de JS válido.
-- **Prova de pré-existência (09/09):** revertido o fix JVM da lane (stash dos
-  8 arquivos do §68, teste mantido) → o JS falha IDÊNTICO; o backend JS ignora
-  `kof_box` (no-op), logo o underflow vem do tratamento de if-expr do próprio
-  backend JS, não do box. Casos excluídos com `Set.of("js")` até o dono do JS
-  corrigir.
+- **Causa raiz:** Em `JsExpressionStatementParser.java`, ao processar `KofConditionalJump`,
+  o compilador drenava incondicionalmente toda a pilha de operandos acumulada até então
+  (`while (!stack.isEmpty())`) para dentro da `condition` antes de determinar se o salto
+  era um `if-expression` ou um `if-statement`. Quando a expressão ocorria como argumento
+  de uma chamada de função (ex.: `println(...)`), o receiver `$kofOut` que já estava na pilha
+  era descartado prematuramente. Ao terminar de emitir o `ifExpr`, apenas o resultado da
+  expressão ficava na pilha, fazendo com que a chamada de função subsequente falhasse com
+  `expression stack underflow`.
+- **Correção:** O empacotamento de preâmbulo na condição só é executado se `tryParseIfExpr(...)`
+  retornar `null` (ou seja, quando for comprovadamente um `if-statement`). Em `if-expression`,
+  os operandos prévios na pilha permanecem intactos.
+- **Provas:** Todos os 5 testes da `ConformanceMatrixTest` com branches heterogêneos
+  (`ifexpr-heterogeneous-direct`, `switchexpr-heterogeneous-direct`, `ifexpr-intlong-direct`,
+  `ifexpr-longdouble-direct`, `ifexpr-intnull-direct`) foram reabilitados para o target JS
+  (remoção de `Set.of("js")`), passando com sucesso no KofJS.
 
 ### 71. JVM: array multidimensional `new Int[2][3]` compila e dá VerifyError — ✅ CORRIGIDO 09/09
 

--- a/kof-compiler/src/main/java/dev/kof/compiler/js/JsExpressionStatementParser.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/js/JsExpressionStatementParser.java
@@ -122,13 +122,13 @@ final class JsExpressionStatementParser {
                 JsIr.JsExpression right = parser.pop(stack);
                 JsIr.JsExpression left = parser.pop(stack);
                 JsIr.JsExpression condition = parser.p.flow.comparisonExpr(cj.comparison(), left, right);
-                while (!stack.isEmpty()) {
-                    condition = new JsIr.JsSequence(List.of(parser.pop(stack)), condition);
-                }
                 JsIr.JsExpression ifExpr = parser.p.flow.tryParseIfExpr(ctx, pos, cj, condition);
                 if (ifExpr != null) {
                     stack.add(ifExpr);
                     continue;
+                }
+                while (!stack.isEmpty()) {
+                    condition = new JsIr.JsSequence(List.of(parser.pop(stack)), condition);
                 }
                 return List.of(parser.p.flow.parseIfBody(ctx, pos, cj, condition, stack));
             }

--- a/kof-compiler/src/test/java/dev/kof/compiler/ConformanceMatrixTest.java
+++ b/kof-compiler/src/test/java/dev/kof/compiler/ConformanceMatrixTest.java
@@ -497,13 +497,13 @@ class ConformanceMatrixTest {
         // primitivos boxeados in-branch + skip do pós-box (só codegen; o
         // check continua aprovando). JS excluído: underflow pré-existente
         // no backend KofJS p/ if heterogêneo (known-bugs §69, provado com
-        // o fix em stash). Paridade JVM+Native+Script (script = oráculo).
+        // Bug 69 CORRIGIDO: paridade JVM+Native+Script+JS.
         matrix("ifexpr-heterogeneous-direct", """
                 main() {
                     var s = ""
                     println(if (s == "") 1 else "s")
                 }
-                """, "1", Set.of("js"), tempDir);
+                """, "1", Set.of(), tempDir);
         // mesma classe da #57 p/ switch-expression heterogêneo.
         matrix("switchexpr-heterogeneous-direct", """
                 main() {
@@ -513,7 +513,7 @@ class ConformanceMatrixTest {
                         default -> "s"
                     })
                 }
-                """, "1", Set.of("js"), tempDir);
+                """, "1", Set.of(), tempDir);
         // §70 — heterogêneo primitivo-vs-primitivo de slots distintos
         // (Int 1-word vs Long 2-word): o join quebrava o COMPUTE_FRAMES
         // (crash AIOOBE) em vez de VerifyError. Fix: cada ramo boxeado
@@ -523,19 +523,19 @@ class ConformanceMatrixTest {
                     var s = ""
                     println(if (s == "") 1 else 2L)
                 }
-                """, "1", Set.of("js"), tempDir);
+                """, "1", Set.of(), tempDir);
         matrix("ifexpr-longdouble-direct", """
                 main() {
                     var s = ""
                     println(if (s == "") 2L else 2.5)
                 }
-                """, "2", Set.of("js"), tempDir);
+                """, "2", Set.of(), tempDir);
         matrix("ifexpr-intnull-direct", """
                 main() {
                     var s = ""
                     println(if (s == "") 1 else null)
                 }
-                """, "1", Set.of("js"), tempDir);
+                """, "1", Set.of(), tempDir);
         matrix("switchexpr", """
                 main() {
                     var v = 3


### PR DESCRIPTION
### Descrição
Resolve o erro interno do compilador `Internal compiler error: KofJS: expression stack underflow (COMP002)` que ocorria ao avaliar expressões condicionais (`if`/`switch`) com branches heterogêneos quando posicionadas como argumentos de funções (ex.: `println(if (s == "") 1 else "s")`).

### Causa Raiz
Em `JsExpressionStatementParser.java`, ao encontrar `KofConditionalJump`, a pilha de expressões era esvaziada incondicionalmente (`while (!stack.isEmpty()) { condition = new JsIr.JsSequence(...); }`) para compor a condição de teste antes de verificar se o salto correspondia a uma expressão condicional (`tryParseIfExpr`) ou a um statement condicional. Isso destruía os operandos precedentes já empilhados (como o receiver `$kofOut`), causando underflow ao desempilhar na chamada de função subsequente.

### Modificações Realizadas
1. **Compilador JS (`JsExpressionStatementParser.java`)**:
   - O esvaziamento da pilha para compor a sequência na `condition` foi postergado para executar somente se `tryParseIfExpr(...)` retornar `null` (caso de statement).
   - Em `if-expression`, a pilha prévia de operandos é preservada intacta.
2. **Matriz de Conformidade (`ConformanceMatrixTest.java`)**:
   - Reabilitados para o backend JS os 5 testes que antes continham `Set.of("js")`:
     - `ifexpr-heterogeneous-direct`
     - `switchexpr-heterogeneous-direct`
     - `ifexpr-intlong-direct`
     - `ifexpr-longdouble-direct`
     - `ifexpr-intnull-direct`
3. **Documentação**:
   - `docs/development/conformance-matrix.md`: Status das 5 entradas de branches heterogêneos atualizado para `DONE (bug 69 corrigido)`.
   - `docs/development/known-bugs.md`: Bug 69 marcado como `✅ CORRIGIDO 09/09 (issue #69)`.

### Validação
- Executados os testes de conformidade e documentação com Maven no JDK 21 Temurin:
  - `ConformanceMatrixDocTest`: 1 run, 0 failures, 0 errors.
  - `ConformanceMatrixTest`: 11 runs (com todos os 5 testes JS reabilitados), 0 failures, 0 errors.
  - `BUILD SUCCESS`.
- Regra de $\le 500$ linhas respeitada (`JsExpressionStatementParser.java` possui 169 linhas).

Closes #69
