### PR TITLE
fix(runtime): kof.ui webview page missing <meta name="viewport">

### DIFF
--- a/kof-runtime/src/main/java/dev/kof/runtime/KofJsWebview.java
+++ b/kof-runtime/src/main/java/dev/kof/runtime/KofJsWebview.java
@@ -28,6 +28,7 @@ final class KofJsWebview {
             Files.copy(ioRuntime, appDir.resolve("kof-runtime-io.mjs"));
         }
         String page = "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n  <meta charset=\"utf-8\">\n"
+                + "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
                 + "  <title>Kof</title>\n  <style>\n"
                 + "    body { margin: 0; font-family: system-ui, sans-serif; }\n"
                 + "    #kof-root { display: flex; flex-direction: column; gap: 8px;\n"


### PR DESCRIPTION
## O que

`KofJsWebview.openInWebview()` monta o `index.html` servido por `kof run --target js` sem `<meta name="viewport">`. Sem essa tag, qualquer navegador mobile real cai no fallback de layout "desktop" (~980px) e escala a página pra caber na tela — mesmo um app kof.ui corretamente responsivo aparece zoomed-out/quebrado num celular de verdade, porque o navegador nunca usa a largura real do device.

Closes #77.

## A correção

Uma linha no `<head>` gerado:

```java
+ "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
```

## Teste

Confirmado via Chrome DevTools Protocol com `Emulation.setDeviceMetricsOverride` nos 4 breakpoints pedidos pelo redesign de `examples/Simulador_simplesnacional` (PR separado) — 360/768/1024/1440px, `document.body.scrollWidth` bate exatamente com a viewport nos 4 casos após a correção.

---
Investigado e corrigido com o auxílio do [Claude Code](https://claude.com/claude-code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)