### PR TITLE
feat(compiler): kof.ui design-system primitives — border/shadow/gradient/flex-basis/max-width

### DIFF
--- a/kof-compiler/src/main/java/dev/kof/compiler/KofUi.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/KofUi.java
@@ -234,6 +234,15 @@ public final class KofUi {
                 case "setClass" -> argCount == 1 ? new UiCall("kof_ui_widget_set_class", Type.PrimitiveType.VOID, List.of(STR)) : null;
                 case "setDisabled" -> argCount == 1 ? new UiCall("kof_ui_widget_set_disabled", Type.PrimitiveType.VOID, List.of(BOOL)) : null;
                 case "on" -> argCount == 2 ? new UiCall("kof_ui_widget_on", Type.PrimitiveType.VOID, List.of(STR, Type.UnknownType.UNKNOWN)) : null;
+                // Design-system pillar (docs/ui/architecture.md §2.8 gap list:
+                // "sem border/sombra/hover/foco... sem margin/fill/grow/shrink"):
+                // four additive, JS-real / JVM+Native-no-op visual primitives,
+                // shared by every DOM widget alongside setClass/setId.
+                case "setBorder" -> argCount == 2 ? new UiCall("kof_ui_widget_set_border", Type.PrimitiveType.VOID, List.of(COLOR, INT)) : null;
+                case "setShadow" -> argCount == 3 ? new UiCall("kof_ui_widget_set_shadow", Type.PrimitiveType.VOID, List.of(COLOR, INT, INT)) : null;
+                case "setGradient" -> argCount == 3 ? new UiCall("kof_ui_widget_set_gradient", Type.PrimitiveType.VOID, List.of(COLOR, COLOR, INT)) : null;
+                case "setFlexBasis" -> argCount == 1 ? new UiCall("kof_ui_widget_set_flex_basis", Type.PrimitiveType.VOID, List.of(INT)) : null;
+                case "setMaxWidth" -> argCount == 1 ? new UiCall("kof_ui_widget_set_max_width", Type.PrimitiveType.VOID, List.of(INT)) : null;
                 default -> null;
             };
             if (shared != null) return shared;

--- a/kof-compiler/src/main/java/dev/kof/compiler/js/JsRuntimeUiWidgets.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/js/JsRuntimeUiWidgets.java
@@ -48,6 +48,31 @@ public final class JsRuntimeUiWidgets {
                 if (n) n.disabled = disabled ? true : false;
             }
 
+            // ── Design-system primitives (border/shadow/gradient/flex) ──
+            // Additive alongside Style(bg,fg,padding,radius): real CSS on the
+            // JS target, no-op on JVM/Native (same split as the rest of kof.ui).
+            export function kofUiWidgetSetBorder(widget, color, width) {
+                const n = window.__kofNodes && window.__kofNodes[widget];
+                if (n) n.style.border = width + "px solid " + kofUiColorToCss(color);
+            }
+            export function kofUiWidgetSetShadow(widget, color, offsetY, blur) {
+                const n = window.__kofNodes && window.__kofNodes[widget];
+                if (n) n.style.boxShadow = "0 " + offsetY + "px " + blur + "px " + kofUiColorToCss(color);
+            }
+            export function kofUiWidgetSetGradient(widget, colorA, colorB, angleDeg) {
+                const n = window.__kofNodes && window.__kofNodes[widget];
+                if (n) n.style.backgroundImage = "linear-gradient(" + angleDeg + "deg, "
+                        + kofUiColorToCss(colorA) + ", " + kofUiColorToCss(colorB) + ")";
+            }
+            export function kofUiWidgetSetFlexBasis(widget, px) {
+                const n = window.__kofNodes && window.__kofNodes[widget];
+                if (n) n.style.flex = "1 1 " + px + "px";
+            }
+            export function kofUiWidgetSetMaxWidth(widget, px) {
+                const n = window.__kofNodes && window.__kofNodes[widget];
+                if (n) { n.style.maxWidth = px + "px"; n.style.width = "100%"; }
+            }
+
             export function kofUiLabelNew(text) {
                 if (typeof document === "undefined") {
                     return -1;

--- a/kof-compiler/src/main/java/dev/kof/compiler/jvm/JvmRuntimeCallDescriptors.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/jvm/JvmRuntimeCallDescriptors.java
@@ -149,6 +149,11 @@ public final class JvmRuntimeCallDescriptors {
              case "kof_ui_widget_set_font" -> "(II)V";
              case "kof_ui_widget_set_id", "kof_ui_widget_set_class" -> "(ILjava/lang/String;)V";
              case "kof_ui_widget_set_disabled" -> "(II)V";
+             case "kof_ui_widget_set_border" -> "(III)V";
+             case "kof_ui_widget_set_shadow" -> "(IIII)V";
+             case "kof_ui_widget_set_gradient" -> "(IIII)V";
+             case "kof_ui_widget_set_flex_basis" -> "(II)V";
+             case "kof_ui_widget_set_max_width" -> "(II)V";
              case "kof_ui_widget_on" -> "(ILjava/lang/String;Ljava/lang/Object;)V";
             case "kof_ui_widget_font" -> "(I)I";
              case "kof_ui_link_set_text", "kof_ui_link_set_url", "kof_ui_image_set_src",

--- a/kof-compiler/src/main/java/dev/kof/compiler/jvm/JvmRuntimeReturnDescriptors.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/jvm/JvmRuntimeReturnDescriptors.java
@@ -107,6 +107,9 @@ public final class JvmRuntimeReturnDescriptors {
              case "kof_ui_router_param", "kof_ui_router_current" -> "Ljava/lang/String;";
              case "kof_ui_label_set_font_size", "kof_ui_label_set_bold", "kof_ui_label_set_color",
                      "kof_ui_window_set_theme" -> "V";
+             case "kof_ui_widget_set_border", "kof_ui_widget_set_shadow",
+                     "kof_ui_widget_set_gradient", "kof_ui_widget_set_flex_basis",
+                     "kof_ui_widget_set_max_width" -> "V";
             // ── kof.security (docs/security.md §5) ───────────────────
             case "kof_sec_sha256", "kof_sec_sha512", "kof_sec_hmac_sha256", "kof_sec_redact",
                     "kof_sec_secret_get", "kof_sec_secret_get_default", "kof_sec_password_hash",

--- a/kof-compiler/src/main/java/dev/kof/compiler/jvm/JvmRuntimeUi.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/jvm/JvmRuntimeUi.java
@@ -131,6 +131,23 @@ public final class JvmRuntimeUi {
                 public static void kof_ui_widget_set_disabled(int widget, int disabled) {
                 }
 
+                // Design-system primitives: real CSS on the JS target only
+                // (kof.ui rendering is KofJS-only, JVM/Native stay no-op).
+                public static void kof_ui_widget_set_border(int widget, int color, int width) {
+                }
+
+                public static void kof_ui_widget_set_shadow(int widget, int color, int offsetY, int blur) {
+                }
+
+                public static void kof_ui_widget_set_gradient(int widget, int colorA, int colorB, int angleDeg) {
+                }
+
+                public static void kof_ui_widget_set_flex_basis(int widget, int px) {
+                }
+
+                public static void kof_ui_widget_set_max_width(int widget, int px) {
+                }
+
                 public static void kof_ui_widget_on(int widget, String type, Object handler) {
                 }
 

--- a/kof-compiler/src/main/java/dev/kof/compiler/runtime/RuntimeUi.java
+++ b/kof-compiler/src/main/java/dev/kof/compiler/runtime/RuntimeUi.java
@@ -340,6 +340,16 @@ public final class RuntimeUi {
                 ret
             kof_ui_widget_set_disabled:
                 ret
+            kof_ui_widget_set_border:
+                ret
+            kof_ui_widget_set_shadow:
+                ret
+            kof_ui_widget_set_gradient:
+                ret
+            kof_ui_widget_set_flex_basis:
+                ret
+            kof_ui_widget_set_max_width:
+                ret
             kof_ui_widget_on:
                 ret
             kof_ui_column_new:


### PR DESCRIPTION
## O que

`Style(bg, fg, padding, radius)` é a única primitiva visual do kof.ui hoje — sem border, box-shadow, gradiente ou controle de flex por widget, exatamente o gap que `docs/ui/architecture.md` já documenta no pilar "Design system"/"Layout". Isso impede construir qualquer coisa além de caixas de cor sólida sem sair da linguagem e escrever CSS à mão.

Closes #78.

## A correção

Cinco métodos de instância novos, compartilhados por todo widget DOM (mesmo grupo de `setClass`/`setId`/`setDisabled` em `KofUi.java`):

```
widget.setBorder(color, widthPx)
widget.setShadow(color, offsetYpx, blurPx)
widget.setGradient(colorA, colorB, angleDeg)
widget.setFlexBasis(px)     // CSS `flex: 1 1 <px>px`
widget.setMaxWidth(px)      // CSS `max-width` + `width:100%`
```

Real no alvo JS (`JsRuntimeUiWidgets.java`), no-op em JVM (`JvmRuntimeUi.java` + as entradas obrigatórias de descritor em `JvmRuntimeCallDescriptors.java`/`JvmRuntimeReturnDescriptors.java` — o JVM não deriva o descritor `invokestatic` da lista de tipos do `KofCall`, procura por nome de função) e Native (`RuntimeUi.java`, stub x86-64 asm, auto-traduzido pra aarch64/riscv) — a mesma divisão JVM/Native no-op que todo o resto do kof.ui já segue.

Puramente aditivo: nenhuma assinatura de construtor/método existente mudou.

`setFlexBasis` combinado com o `flex-wrap` do Row (ver PR #79) dá layout responsivo de N colunas → 1 coluna sem nenhuma feature de media query, que o kof.ui não tem.

## Teste

Compila isoladamente (`mvn -pl kof-compiler compile`), sem depender das outras duas PRs. Exercitado de ponta a ponta em `examples/Simulador_simplesnacional` (PR separado): cards com borda+sombra reais, botão e painel de resultado com gradiente, layout responsivo via `setFlexBasis`/`setMaxWidth` — validado nos 4 breakpoints (360/768/1024/1440px) via Chrome DevTools Protocol.

---
Desenhado e implementado com o auxílio do [Claude Code](https://claude.com/claude-code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)