### PR TITLE
feat(cli): adicionar suporte à flag --json no comando kof check

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ completo com cada sistema, checksum e solução de problemas) e
 kof build <dir> [--target jvm|native|native.risc|native.arm|js|android] [--output <dir>] [--release]
 kof run <file.kf> [--target jvm|native|native.risc|native.arm|js] [args...]
 kof serve <file.kf> [--port <port>] [--host <host>]
-kof check <file.kf|dir>
+kof check <file.kf|dir> [--json]
 kof test <file.kf|dir> [--target jvm|native|js]
 kof script | repl | c | fmt | config
 kof bench | profile | inspect | debug

--- a/docs/tooling/README.md
+++ b/docs/tooling/README.md
@@ -102,4 +102,5 @@ semântica do programa.
 
 `kof check` executa o pipeline completo (Lexer → Parser → Semantic Analysis)
 sem emitir código, reportando todos os erros. O LSP publica o mesmo conjunto
-de diagnósticos, com os mesmos códigos, em tempo de edição.
+de diagnósticos, com os mesmos códigos, em tempo de edição. Com a flag `--json`,
+o `kof check` produz saída estruturada para ferramentas de análise e CI/CD.

--- a/kof-cli/src/main/java/dev/kof/cli/CmdCheck.java
+++ b/kof-cli/src/main/java/dev/kof/cli/CmdCheck.java
@@ -1,0 +1,143 @@
+package dev.kof.cli;
+
+import dev.kof.compiler.CompilationResult;
+import dev.kof.compiler.CompilerDriver;
+import dev.kof.compiler.Diagnostic;
+import dev.kof.compiler.Target;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+final class CmdCheck {
+
+    private CmdCheck() {}
+
+    static int run(String[] args) {
+        return run(args, System.out, System.err);
+    }
+
+    static int run(String[] args, PrintStream out, PrintStream err) {
+        if (args.length < 2) {
+            err.println("usage: kof check <file.kf|dir> [--json]");
+            return 1;
+        }
+
+        boolean json = false;
+        String pathArg = null;
+
+        for (int i = 1; i < args.length; i++) {
+            String arg = args[i];
+            if ("--help".equals(arg) || "-h".equals(arg) || "--version".equals(arg)) {
+                out.println("usage: kof check <file.kf|dir> [--json]");
+                return 0;
+            } else if ("--json".equals(arg)) {
+                json = true;
+            } else if (pathArg == null && !arg.startsWith("-")) {
+                pathArg = arg;
+            }
+        }
+
+        if (pathArg == null) {
+            err.println("usage: kof check <file.kf|dir> [--json]");
+            return 1;
+        }
+
+        Path src = Path.of(pathArg);
+        if (!Files.exists(src)) {
+            err.println("not found: " + src);
+            return 1;
+        }
+
+        List<Path> files = Files.isDirectory(src) ? KofCliSupport.collect(src) : List.of(src);
+        if (files.isEmpty()) {
+            if (json) {
+                out.println("{\"success\":true,\"filesChecked\":0,\"errorCount\":0,\"diagnostics\":[]}");
+            } else {
+                out.println("no .kf/.kof files found");
+            }
+            return 0;
+        }
+
+        CompilerDriver driver = new CompilerDriver();
+        int count = files.size();
+        Path tmp;
+        try {
+            tmp = Files.createTempDirectory("kof-check-");
+        } catch (IOException e) {
+            err.println("failed to create temp dir: " + e.getMessage());
+            return 1;
+        }
+
+        CompilationResult r;
+        try {
+            r = files.size() > 1
+                    ? driver.compileSources(files.stream()
+                            .map(p -> p.toAbsolutePath().normalize()).distinct()
+                            .collect(Collectors.toList()), tmp, Target.JVM,
+                            src.toAbsolutePath().normalize())
+                    : driver.compile(files.get(0), tmp, Target.JVM);
+        } finally {
+            KofCliSupport.cleanup(tmp);
+        }
+
+        List<Diagnostic> diagnostics = r.diagnostics().getDiagnostics();
+        long errorCount = diagnostics.stream()
+                .filter(d -> d.severity() == Diagnostic.Severity.ERROR)
+                .count();
+
+        boolean success = r.success() && errorCount == 0;
+
+        if (json) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("{\"success\":").append(success)
+                    .append(",\"filesChecked\":").append(count)
+                    .append(",\"errorCount\":").append(errorCount)
+                    .append(",\"diagnostics\":[");
+            for (int i = 0; i < diagnostics.size(); i++) {
+                if (i > 0) sb.append(",");
+                Diagnostic d = diagnostics.get(i);
+                sb.append("{\"code\":\"").append(jsonEscape(d.code() != null ? d.code() : ""))
+                        .append("\",\"file\":\"").append(jsonEscape(d.file() != null ? d.file() : ""))
+                        .append("\",\"line\":").append(d.line())
+                        .append(",\"column\":").append(d.column())
+                        .append(",\"length\":").append(d.length())
+                        .append(",\"severity\":\"").append(d.severity() != null ? d.severity().name() : "ERROR")
+                        .append("\",\"message\":\"").append(jsonEscape(d.message() != null ? d.message() : ""))
+                        .append("\"}");
+            }
+            sb.append("]}");
+            out.println(sb.toString());
+        } else {
+            for (Diagnostic d : diagnostics) {
+                out.println(d.format());
+            }
+            if (success) {
+                out.println("checked " + count + " file(s) — no errors");
+            }
+        }
+
+        return success ? 0 : 1;
+    }
+
+    private static String jsonEscape(String s) {
+        StringBuilder sb = new StringBuilder();
+        for (char c : s.toCharArray()) {
+            switch (c) {
+                case '"' -> sb.append("\\\"");
+                case '\\' -> sb.append("\\\\");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                default -> {
+                    if (c < 0x20) sb.append(String.format("\\u%04x", (int) c));
+                    else sb.append(c);
+                }
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/kof-cli/src/main/java/dev/kof/cli/Main.java
+++ b/kof-cli/src/main/java/dev/kof/cli/Main.java
@@ -18,7 +18,7 @@ public final class Main {
             case "build" -> CmdBuild.run(args);
             case "run" -> CmdRun.run(args);
             case "serve" -> CmdServe.run(args);
-            case "check" -> check(args);
+            case "check" -> System.exit(CmdCheck.run(args));
             case "test" -> CmdTest.run(args);
             case "bench" -> System.exit(Bench.run(args));
             case "profile" -> System.exit(Profile.run(args));
@@ -49,7 +49,7 @@ public final class Main {
         System.out.println("  build <dir> [--target jvm|native|js|android] [--output <dir>] [--release] [--apk]");
         System.out.println("  run <file.kf> [--target jvm|native|js|android] [--release] [args...]");
         System.out.println("  serve <file.kf> [--port <port>] [--host <host>]");
-        System.out.println("  check <file.kf|dir>          type-check without emitting output");
+        System.out.println("  check <file.kf|dir> [--json]   type-check without emitting output");
         System.out.println("  script <file.ks|kf> [--target jvm|native|js]   execução direta KofScript (JVM/Native/JS, diagnostics com file:line)");
         System.out.println("  repl                         REPL incremental KofScript (type 'exit' to quit)");
         System.out.println("  test <file.kf|dir> [--target jvm|native]   run programs, PASS/FAIL by exit code");
@@ -282,36 +282,6 @@ public final class Main {
             e.printStackTrace();
             System.exit(1);
         }
-    }
-
-    private static void check(String[] args) {
-        if (args.length < 2) { System.err.println("usage: kof check <file.kf|dir>"); System.exit(1); return; }
-        if ("--help".equals(args[1]) || "-h".equals(args[1]) || "--version".equals(args[1])) {
-            System.out.println("usage: kof check <file.kf|dir>");
-            return;
-        }
-        Path src = Path.of(args[1]);
-        if (!Files.exists(src)) { System.err.println("not found: " + src); System.exit(1); return; }
-        List<Path> files = Files.isDirectory(src) ? KofCliSupport.collect(src) : List.of(src);
-        if (files.isEmpty()) { System.out.println("no .kf/.kof files found"); return; }
-        CompilerDriver driver = new CompilerDriver();
-        boolean ok = true;
-        int count = files.size();
-        Path tmp;
-        try { tmp = Files.createTempDirectory("kof-check-"); }
-        catch (IOException e) { System.err.println("failed to create temp dir: " + e.getMessage()); System.exit(1); return; }
-        // diretório = um módulo (mesmo modelo do build/run); arquivo único = isolado
-        CompilationResult r = files.size() > 1
-                ? driver.compileSources(files.stream()
-                        .map(p -> p.toAbsolutePath().normalize()).distinct()
-                        .collect(java.util.stream.Collectors.toList()), tmp, Target.JVM,
-                        src.toAbsolutePath().normalize())
-                : driver.compile(files.get(0), tmp, Target.JVM);
-        for (Diagnostic d : r.diagnostics().getDiagnostics()) System.out.println(d.format());
-        KofCliSupport.cleanup(tmp);
-        if (!r.success()) ok = false;
-        if (!ok) System.exit(1);
-        System.out.println("checked " + count + " file(s) — no errors");
     }
 
     private static void info(String[] args) {

--- a/kof-cli/src/test/java/dev/kof/cli/CmdCheckTest.java
+++ b/kof-cli/src/test/java/dev/kof/cli/CmdCheckTest.java
@@ -1,0 +1,133 @@
+package dev.kof.cli;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CmdCheckTest {
+
+    @Test
+    void checkTextOutputSuccess(@TempDir Path tmp) throws Exception {
+        Path file = tmp.resolve("Main.kf");
+        Files.writeString(file, "main() { println(\"ok\") }");
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        int ec = CmdCheck.run(new String[]{"check", file.toString()},
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8));
+
+        assertEquals(0, ec);
+        String output = out.toString(StandardCharsets.UTF_8).trim();
+        assertTrue(output.contains("checked 1 file(s) — no errors"), output);
+    }
+
+    @Test
+    void checkTextOutputFailure(@TempDir Path tmp) throws Exception {
+        Path file = tmp.resolve("Main.kf");
+        Files.writeString(file, "main() { val x: Int = \"invalido\" }");
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        int ec = CmdCheck.run(new String[]{"check", file.toString()},
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8));
+
+        assertEquals(1, ec);
+        String output = out.toString(StandardCharsets.UTF_8).trim();
+        assertTrue(output.contains("error:") || output.contains("SEM021"), output);
+    }
+
+    @Test
+    void checkJsonOutputSuccess(@TempDir Path tmp) throws Exception {
+        Path file = tmp.resolve("Main.kf");
+        Files.writeString(file, "main() { val a = 10; println(a) }");
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        int ec = CmdCheck.run(new String[]{"check", file.toString(), "--json"},
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8));
+
+        assertEquals(0, ec);
+        String output = out.toString(StandardCharsets.UTF_8).trim();
+        assertTrue(output.contains("\"success\":true"), output);
+        assertTrue(output.contains("\"filesChecked\":1"), output);
+        assertTrue(output.contains("\"errorCount\":0"), output);
+        assertTrue(output.contains("\"diagnostics\":[]"), output);
+    }
+
+    @Test
+    void checkJsonOutputFailure(@TempDir Path tmp) throws Exception {
+        Path file = tmp.resolve("Main.kf");
+        Files.writeString(file, "main() { val x: Int = \"invalido\" }");
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        int ec = CmdCheck.run(new String[]{"check", file.toString(), "--json"},
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8));
+
+        assertEquals(1, ec);
+        String output = out.toString(StandardCharsets.UTF_8).trim();
+        assertTrue(output.contains("\"success\":false"), output);
+        assertTrue(output.contains("\"errorCount\":1"), output);
+        assertTrue(output.contains("\"severity\":\"ERROR\""), output);
+        assertTrue(output.contains("\"code\":\"SEM021\""), output);
+        assertTrue(output.contains("\"message\":"), output);
+        assertTrue(output.contains("\"file\":"), output);
+    }
+
+    @Test
+    void checkJsonEmptyDirectory(@TempDir Path tmp) throws Exception {
+        Path emptyDir = tmp.resolve("empty");
+        Files.createDirectories(emptyDir);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        int ec = CmdCheck.run(new String[]{"check", emptyDir.toString(), "--json"},
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8));
+
+        assertEquals(0, ec);
+        String output = out.toString(StandardCharsets.UTF_8).trim();
+        assertEquals("{\"success\":true,\"filesChecked\":0,\"errorCount\":0,\"diagnostics\":[]}", output);
+    }
+
+    @Test
+    void checkJsonArgOrderFlexible(@TempDir Path tmp) throws Exception {
+        Path file = tmp.resolve("Main.kf");
+        Files.writeString(file, "main() { println(\"ok\") }");
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        int ec = CmdCheck.run(new String[]{"check", "--json", file.toString()},
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8));
+
+        assertEquals(0, ec);
+        String output = out.toString(StandardCharsets.UTF_8).trim();
+        assertTrue(output.contains("\"success\":true"), output);
+        assertTrue(output.contains("\"diagnostics\":[]"), output);
+    }
+
+    @Test
+    void checkHelpOutputsJsonOption() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        int ec = CmdCheck.run(new String[]{"check", "--help"},
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8));
+
+        assertEquals(0, ec);
+        String output = out.toString(StandardCharsets.UTF_8).trim();
+        assertTrue(output.contains("--json"), output);
+    }
+}

--- a/learn/32-cli-tooling.md
+++ b/learn/32-cli-tooling.md
@@ -19,7 +19,7 @@ A CLI é a ferramenta central da plataforma Kof.
 | `kof repl` | REPL incremental KofScript (type `exit` to quit) |
 | `kof c <file.c> [--run] [--output <bin>]` | KofC C subset → ELF x86-64 nativo-only |
 | `kof serve <file.kf>` | Web server HTTP (`web.app()` nativo + API legada `handle()`) |
-| `kof check <file.kf\|dir>` | Type-check sem emitir código |
+| `kof check <file.kf\|dir> [--json]` | Type-check sem emitir código |
 | `kof test <file.kf\|dir> [--target jvm|native|js]` | Suíte estruturada `test "nome" { assert(...) }` nos 3 targets + programas inteiros por exit code |
 | `kof bench [paths...] [--target ...] [--iterations N] [--baseline <file>] [--threshold <ratio>] [--json] [--fail-on-regression]` | Benchmark harness (compile, run, validate, métricas, baseline) |
 | `kof profile <file.kf> [--target ...]` | Execução + métricas (CPU, RSS, GC) |
@@ -64,6 +64,8 @@ Formato estruturado: `kof info --json`.
 
 Executa o pipeline completo (Lexer → Parser → Análise Semântica) e reporta
 todos os erros, sem emitir código. É a mesma checagem que o LSP publica.
+Com a flag `--json` (`kof check <file.kf|dir> --json`), emite os diagnósticos
+em formato JSON estruturado para automação e integração contínua (CI/CD).
 
 ## `kof script` e `kof c` (0.2.0)
 


### PR DESCRIPTION
## Descrição

Adiciona suporte à flag `--json` no comando `kof check`, permitindo a geração de diagnósticos estruturados em formato JSON para fácil integração com linters, IDEs, editores externos e fluxos de CI/CD.

A lógica de checagem foi modularizada na nova classe `CmdCheck`, alinhando-se à arquitetura dos demais comandos (`CmdBuild`, `CmdRun`, etc.) e viabilizando testes unitários isolados com injeção de streams.

## Alterações Realizadas

- **`CmdCheck.java`**: Criada classe dedicada de comando (`dev.kof.cli.CmdCheck`) com tratamento da flag `--json` e geração de JSON estruturado (`success`, `filesChecked`, `errorCount`, `diagnostics`).
- **`Main.java`**: Delegado `case "check"` para `CmdCheck.run(args)` e atualizado o menu de ajuda.
- **`CmdCheckTest.java`**: Adicionados 7 testes unitários cobrindo fluxos de texto, json, sucesso, falha, ordenação flexível de argumentos e diretórios vazios.
- **Documentação**: Atualizados `README.md`, `learn/32-cli-tooling.md` e `docs/tooling/README.md`.

## Evidência de Testes

- Suíte de testes automatizados do CLI executada com sucesso via Maven com JDK 21 (`CmdCheckTest`):
  - `Tests run: 7, Failures: 0, Errors: 0, Skipped: 0`
  - `BUILD SUCCESS`


Closes #84 