### PR TITLE
docs(otp): emendas verificadas ao plano de supervisão + fechamento das 8 DDs independentes

### DIFF
--- a/docs/development/planning-otp-supervision.md
+++ b/docs/development/planning-otp-supervision.md
@@ -1,7 +1,36 @@
 # planning-otp-supervision.md — supervisão de workers estilo OTP (`one_for_one`) — PROPOSED
 
 **Dono:** lane CONC · **Status:** PROPOSED (aguarda decisão da mantenedora — regra 6)
-**Criado:** 10/09 · **Issue:** #83 (ViniciusKoiti) · **Zero código nesta fase**
+**Criado:** 10/09 · **Emendado:** 11/09 · **Issue:** #83 (ViniciusKoiti) · **Zero código nesta fase**
+
+> **Emendas de 11/09** (verificadas no código da `beta-0.4.0`, marcadas
+> inline como "⚠️ Emenda 11/09"): §Separação de responsabilidades (nova),
+> DD-OTP-01, 02, 03, 08, 09, 11 e a fatia S2. O motivo comum das duas
+> emendas materiais: `selectAny` **não existe** em riscv64/aarch64, e a
+> flag de shutdown depende de uma regra do SG-020 que ainda não tem prova.
+
+## Estado das decisões (11/09)
+
+| DD | Assunto | Estado |
+|---|---|---|
+| 01 | Forma (stdlib puro-Kof) | ⚠️ fechável **com emenda** — falta especificar o empacotamento de stdlib em `.kf` |
+| 02 | Superfície (API) | ⚠️ fechável **com emenda** — a assinatura precisa declarar a camada |
+| 03 | N workers sem bloquear | ❌ **ABERTA** — `selectAny` ausente em riscv/aarch; falta decidir o fallback |
+| 04 | O que conta como falha | ✅ fechada |
+| 05 | Plano ou árvore | ✅ fechada |
+| 06 | Estado no restart | ✅ fechada |
+| 07 | Escalonamento | ✅ fechada (contradição do texto resolvida) |
+| 08 | Shutdown | 🚫 **BLOQUEADA** — regra 5 do SG-020 sem prova |
+| 09 | Alvos | ❌ **ABERTA** — depende do 03 |
+| 10 | Relógio injetável | ✅ fechada |
+| 11 | Métrica de sucesso | ✅ fechada (quatro gates) |
+| 12 | Onde os testes moram | ✅ fechada |
+| 13 | Colisão do `cancelled()` | ✅ fechada (condicional ao 08) |
+
+**8 fechadas · 2 fecháveis com emenda · 2 abertas · 1 bloqueada.**
+As 8 são independentes entre si — podem ser ratificadas sem esperar as outras.
+O caminho crítico é só o **DD-OTP-08**, e ele se resolve com um teste, não
+com design: o padrão stop-flag (escritor + leitor em laço com deadline).
 
 A issue #83 traz a análise OTP-vs-Kof completa e correta. Este documento
 **verificou cada afirmação dela contra o código atual** (tudo confirmado —
@@ -27,6 +56,31 @@ compartilhado (o defeito p/ restart limpo) é a alavanca do shutdown
 cooprativo cross-target: uma `Bool` capturada em `Box` é visível ao worker
 em TODOS os targets, sem depender do `cancelled()` quebrado em 2 dos 5.
 
+## Separação de responsabilidades (supervisor / runtime / worker)
+
+> ⚠️ **Emenda 11/09** — seção nova. É o "ponto principal" declarado pela
+> mantenedora na discussão da #83 e não estava no documento. Os DDs dizem
+> *onde mora o código*; esta tabela diz *quem garante o quê*. Sem ela, a
+> feature tende a virar mecanismo por backend.
+
+| Camada | Responsabilidade | Estado hoje |
+|---|---|---|
+| **Supervisor** | acompanhar filhos, detectar encerramento, aplicar política de reinício, controlar shutdown | não existe |
+| **Runtime** | fornecer término observável, cancelamento e tempo | parcial — término só via `Handle`+`await`; `spawn` comando **engole** a exceção (`JvmRuntimeCore.java:195-205`); `cancelled()` = `0` em JS/interp; `time.now()` ok |
+| **Worker** | cooperar: checar a flag de parada e ser reconstruível pela fábrica | contrato hoje implícito — precisa virar documentado |
+
+Duas fronteiras que estão borradas hoje e que esta separação corrige:
+
+1. **Política no runtime.** `kof_spawn` decide sozinho o que fazer com a
+   falha (imprime em stderr e segue) — isso é decisão de política dentro da
+   camada de mecanismo. O supervisor só enxerga o que passa por
+   `spawn expr` + `Handle`; `spawn` como comando é invisível para ele.
+   **Consequência para a API:** todo filho supervisionado precisa nascer
+   como `spawn` expressão, e isso é contrato, não detalhe.
+2. **Responsabilidade sem contrato no worker.** `cancelled()` e a flag do
+   DD-OTP-08 só funcionam se o worker checar. Isso deve estar escrito na
+   assinatura do `.child(...)`, não no texto de um tutorial.
+
 ## Os DDs (cada um: opções + recomendação)
 
 ### DD-OTP-01 — Forma: onde mora a lógica
@@ -44,6 +98,17 @@ em TODOS os targets, sem depender do `cancelled()` quebrado em 2 dos 5.
 - Complexidade pertence à plataforma, e a plataforma Kof já tem
   spawn/await/try-catch: o supervisor é **código Kof**, não feature de VM.
 
+> ⚠️ **Emenda 11/09 — falta o mecanismo de empacotamento.** A decisão (A)
+> está certa, mas a analogia *"objeto como `kof.mq`/`scheduler`"* não se
+> sustenta: `kof.mq` e `kof.scheduler` **não são Kof puro** — são
+> `KofMq.java` e `KofScheduler.java`, código Java no compilador com runtime
+> emitido por backend. **Não existe hoje nenhum módulo de stdlib escrito em
+> `.kf`.** O único precedente de fonte Kof empacotada é
+> `kof-compiler/src/main/resources/dev/kof/android-host.kf` (resource).
+> **Pendência:** especificar como uma stdlib em Kof é compilada e ligada ao
+> programa do usuário em cada alvo. Enquanto isso não estiver escrito, o
+> "zero código de backend" da fatia S1 está subestimado.
+
 ### DD-OTP-02 — Superfície (API)
 Proposta (mínima, aditiva, experimental tier R5):
 ```kof
@@ -58,6 +123,14 @@ supervisorStats()                                 // {started, restarts, dropped
 ```
 Sem monitor nomeado / árvore (DD-OTP-05) — pilha mínima primeiro.
 
+> ⚠️ **Emenda 11/09 — a API precisa declarar a camada.** A superfície lista
+> métodos mas não diz o que o supervisor *promete*, o que ele *exige do
+> runtime* e o que *exige do worker*. Como a separação de responsabilidades
+> é o ponto central da proposta, isso pertence à assinatura:
+> `.child(id, factory, policy)` deve documentar que `factory` **cria** o
+> worker (DD-OTP-06) e que o worker **precisa checar a flag de parada**
+> (DD-OTP-08) para que `.stop()` tenha efeito.
+
 ### DD-OTP-03 — N workers sem bloquear
 **N por supervisor (recomendado):** a thread supervisora roda
 `while (ativos) { await handle_morto }` — mas `await` bloqueia num só.
@@ -68,7 +141,29 @@ thread supervisora). Alternativa (thread supervisora por worker) é 1-thread
 por filho — aceitável no JVM virtual-threads, pior no x86. Recomendo
 `selectAny` primeiro; medir.
 
+> ⚠️ **Emenda 11/09 — `selectAny` não existe em dois alvos.**
+> `nat/NativeRiscvSpawn.java` emite **apenas** `kof_spawn_result`,
+> `kof_spawn`, `kof_await` e `kof_spawn_join_all`. Não há
+> `kof_select_any`, `kof_poll`, `kof_done`, `kof_cancel` nem
+> `kof_await_timeout` em nenhum emissor riscv/aarch64 — e **não há gate de
+> compile-time**, então o uso cai em erro de link por símbolo indefinido
+> (padrão do bug 59), não num gap honesto. **Emenda:** o mecanismo de N
+> workers precisa de fallback declarado — uma thread supervisora por filho
+> onde `selectAny` não existe — ou riscv/aarch ficam limitados a **um
+> worker por supervisor**, registrado como PARTIAL.
+
 ### DD-OTP-04 — O que conta como falha
+
+> **✅ DECIDIDO — proposta de fechamento 11/09, aguarda ratificação (regra 6):**
+> falha = exceção (String) não capturada que escapa do corpo do worker.
+> Término normal é falha **apenas** em `permanent`. Heartbeat/hang fica
+> fora, em fila própria (`OTP002`).
+>
+> **Limitação aceita e documentada:** exceções em Kof são `String`, sem
+> hierarquia de tipos, e no Native o primeiro `catch` sempre captura — logo
+> a política de reinício **não pode discriminar por tipo de erro**, só pela
+> policy declarada no filho. Isso é contrato explícito, não omissão.
+
 - exceção (String) não capturada → falha (único sinal cross-target real);
 - terminar normal → **não** é falha em `transient`/`temporary`, é falha em
   `permanent` (semântica OTP, traduzível 1:1 com `await` que retorna);
@@ -77,12 +172,26 @@ por filho — aceitável no JVM virtual-threads, pior no x86. Recomendo
   caro. Fila própria (`OTP002` se promovida), nunca meia-implementada.
 
 ### DD-OTP-05 — Plano ou árvore
+
+> **✅ DECIDIDO — proposta de fechamento 11/09, aguarda ratificação (regra 6):**
+> supervisor plano, sem aninhamento. A resposta ao estouro do limite é o
+> callback do DD-OTP-07, não um pai. A abstração de filho nasce genérica o
+> bastante para aninhar depois sem quebrar a API. Árvore só com demanda real.
+
 **Plano, sem aninhamento (recomendado p/ 1ª fatia).** Árvore exige
 supervisor-como-filho + escalonamento semântico entre pais — puxa a
 superfície inteira. Sem árvore, a resposta ao estouro é o callback do
 DD-OTP-07. Reavaliar só com demanda real.
 
 ### DD-OTP-06 — Estado no restart
+
+> **✅ DECIDIDO — proposta de fechamento 11/09, aguarda ratificação (regra 6):**
+> o reinício **sempre** recria o worker pela fábrica; nunca reaproveita o
+> estado que levou à falha. Confirmado pela mantenedora na discussão da #83.
+> `.child(id, factory, policy)` documenta na própria assinatura que
+> `factory` **cria** o worker. Sem isolamento de heap é o mais forte que se
+> pode garantir — reiniciar sobre a closure velha é crash-loop até o limite.
+
 **Exigir fábrica que reconstrói (recomendado e travado na API):** o tipo do
 `child(id, factory, ...)` documenta `factory = () -> worker` que **cria** o
 estado (novos records/vars por restart). Não há como fazer melhor sem
@@ -91,6 +200,22 @@ sobre a closure velha = crash-loop até o limite (a armadilha que a issue
 aponta). Documentar no training: "factory nova = estado novo".
 
 ### DD-OTP-07 — Escalonamento (estouro do limite)
+
+> **✅ DECIDIDO — proposta de fechamento 11/09, aguarda ratificação (regra 6):**
+> `.escalate(fn)` é **opcional, com default definido** — não obrigatório.
+> Isso resolve uma contradição do texto original, que pedia *"callback
+> obrigatório no start() se há limite"* e na linha seguinte descrevia um
+> *"default sem `.escalate`"*: se fosse obrigatório, não haveria default.
+>
+> - **com** `.escalate(fn)`: ao estourar o limite o supervisor chama
+>   `fn(id, motivo, contagem)` na thread supervisora e para de reiniciar
+>   aquele filho — o usuário decide o que fazer;
+> - **sem** `.escalate`: diagnóstico R6 no stderr e o supervisor para de
+>   reiniciar aquele filho.
+>
+> Em nenhum dos dois casos o supervisor mata o processo, e em nenhum ele
+> desiste em silêncio (R6).
+
 Sem pai na árvore, as opções honestas: (a) matar processo — brutal, e
 `process.exit` é interop (não stdlib-pura); (b) desistir em silêncio —
 **proibido (R6)**; (c) **callback `.escalate(fn)` obrigatório no start() se
@@ -108,6 +233,25 @@ nunca silencioso). `cancel(handle)` do runtime é bônus onde funciona (JVM/
 x86), nunca a única alavanca. O join implícito é liberado quando o laço da
 supervisora termina — nada novo aqui, só honestidade no deadline.
 
+> ⚠️ **Emenda 11/09 — BLOQUEADA: a flag não tem garantia de visibilidade.**
+> A afirmação *"uma `Bool` capturada em `Box` é visível ao worker em TODOS
+> os targets"* depende da **regra 5 do SG-020** (SC para statics e campos
+> compartilhados). Essa regra **ainda não está provada**: o teste citado,
+> `KofConcurrency2Test.staticsAreSequentiallyConsistent:699`, não tem
+> nenhuma escrita concorrente em campo compartilhado — declara
+> `Resultado.r1..r4` e nunca os usa; o que prova é a borda do **await**. E
+> `volatile` é non-goal da linguagem (SG-020 §5), com
+> `BoxClassFactory.java:25` criando o campo como `AccessFlags.PUBLIC`
+> simples (`ACC_VOLATILE` não aparece em nenhum ponto do compilador).
+> Na JVM, portanto, `while (!parar.value)` pode ter a leitura içada do laço
+> e **nunca observar o `stop()`** — falha que passa em teste curto e trava
+> em worker de longa duração, exatamente o caso de uso da feature.
+> **Destrava com:** um E2E do padrão stop-flag (escritor + leitor em laço,
+> com deadline que falha se a escrita não for observada), ou reescrita da
+> regra 5. Se a flag própria cair, a alternativa é o `cancel` do runtime —
+> e aí o **bug 101 deixa de ser independente e passa a bloquear**
+> (ver DD-OTP-13).
+
 ### DD-OTP-09 — Alvos
 Puro-Kof (DD-OTP-01-A) = **JVM + Script + JS + Native x86 + riscv/aarch de
 graça** (tudo usa só spawn/await/selectAny já existentes). Sem `OTP001` —
@@ -115,12 +259,40 @@ nenhum gap novo nasce desta feature (a restrição JS-01 não alcança
 task-lambda; registrar no doc de paridade). `selectAny` polling no x86 é o
 custo de regime, não de correção.
 
+> ⚠️ **Emenda 11/09 — a cobertura declarada está errada.** "riscv/aarch de
+> graça" é falso: `selectAny`, de que o DD-OTP-03 depende, não existe
+> nesses alvos (ver emenda do DD-OTP-03). Isso contraria o princípio
+> enunciado pela mantenedora — *"não faz sentido definir uma API que
+> funcione bem em um backend e seja apenas uma promessa nos outros"*.
+> **Cobertura real:** JVM + Native x86_64 + JS + Script. **riscv64/aarch64
+> = PARTIAL declarada**, limitados a um worker por supervisor até alguém
+> portar os auxiliares (trabalho da lane Native, junto com o gate R6 que
+> hoje também falta).
+
 ### DD-OTP-10 — Relógio injetável
+
+> **✅ DECIDIDO — proposta de fechamento 11/09, aguarda ratificação (regra 6):**
+> `.clock(nowFn)`, default `time.now()`. Custo de um campo. É o que torna o
+> gate de limite de reinícios determinístico em todos os alvos, e o que faz
+> um teste cross sob qemu medir o supervisor em vez de medir o emulador.
+
 **Sim (recomendado):** `.clock(nowFn)` default `time.now()`. Teste de
 janela roda determinístico em todos os alvos, sem esperar wall-clock
 (qemu distorce tempo — a issue acerta). Custo: 1 campo.
 
 ### DD-OTP-11 — Métrica de sucesso
+
+> **✅ DECIDIDO — proposta de fechamento 11/09, aguarda ratificação (regra 6):**
+> os **quatro gates** da emenda abaixo são o critério de fechamento do
+> núcleo mínimo. O orçamento de regime normal é **medido, não prometido**.
+> Throughput sob falha fica fora (exigiria harness novo — `kof bench` só
+> mede wall-clock de processo curto).
+>
+> **Registrado explicitamente:** supervisão **não é feature de desempenho**.
+> Em regime sem falha, com supervisor é igual ou pior que sem. O ganho é
+> disponibilidade — e o benchmark de overhead existe para provar que o custo
+> é pequeno, não para mostrar ganho.
+
 **Gate booleano de contenção (recomendado p/ fechar a feature):** E2E —
 worker que lança na 1ª invocação e termina na 2ª → supervisor reinicia,
 programa completa, `supervisorStats().restarts == 1`. Orçamento de
@@ -128,7 +300,28 @@ regime-normal: supervisor vazio + 1 worker ok adds <5ms ao boot
 (medido, não prometido). Throughput sob falha: FORA (harness novo —
 fila própria se pedido).
 
+> ⚠️ **Emenda 11/09 — são quatro gates, não um.** A mantenedora nomeou
+> explicitamente os testes que fecham o núcleo mínimo; o texto acima cobre
+> só o segundo:
+>
+> | Gate | Prova | Encosta em |
+> |---|---|---|
+> | Observação de falha | o supervisor **sabe** que o filho morreu | `spawn expr` + `Handle` |
+> | Reinício individual | só o que morreu reinicia; os outros seguem | `one_for_one` + `.child(...)` |
+> | Limite de reinícios | N reinícios em janela T param o ciclo | `.restartLimit` + `.clock` |
+> | Encerramento controlado | `.stop()` termina de fato, sem pendurar no join implícito | `.stop()` + DD-OTP-08 |
+>
+> O quarto gate depende do DD-OTP-08, hoje bloqueado.
+
 ### DD-OTP-12 — Onde os testes moram
+
+> **✅ DECIDIDO — proposta de fechamento 11/09, aguarda ratificação (regra 6):**
+> E2E determinístico com `.clock()` injetado, **fora** da matriz de equality
+> — o construto é não-determinístico por natureza, como `random.*`/`uuid`.
+> Paridade por asserts de contrato nos alvos, padrão já estabelecido em
+> `KofRandomTest`. CI: a matriz de target atual basta; eixo JDK (fallback de
+> platform thread) e `bench`/long-run ficam em fila própria.
+
 E2E determinístico com `.clock()` injetado (não conflita com as exclusões
 da matriz: **não entra na matriz** equality — é não-determinístico por
 natureza, como `random.*`/`uuid`; paridade por asserts de contrato nos 5
@@ -137,6 +330,14 @@ basta (não exigir eixo JDK novo — registrar fallback platform-thread como
 teste separado e menor, `bench`/long-run são fila própria).
 
 ### DD-OTP-13 — Colisão do `cancelled()` (256 slots)
+
+> **✅ DECIDIDO — proposta de fechamento 11/09, aguarda ratificação (regra 6):**
+> bug 101 (flag por `TID % 256`, dois workers podem herdar o cancel um do
+> outro) é trabalho **independente** da lane Native e **não bloqueia**
+> supervisão — **enquanto** o DD-OTP-08 usar flag própria. Se o DD-OTP-08
+> cair para o `cancel` do runtime, este item **vira bloqueador**.
+> Dependência registrada explicitamente.
+
 Bug independente (a issue pede registro): **bug 101 em `known-bugs.md`** —
 flag por `TID % 256`, dois workers podem herdar cancel do outro. Fix
 possível (tabela maior + chaining por ponteiro de handle) é da lane
@@ -147,8 +348,10 @@ Native; pequeno e isolado. Não bloqueia OTP (que usa flag própria).
 1. **S1 (1 sessão):** `kof.supervisor` puro-Kof no runtime stdlib +
    `.child/.restartLimit/.clock/.start/.stop/.escalate` + E2E JVM/JS
    (DD-OTP-11 gate) + doc/learn/training. Zero código de backend.
-2. **S2:** Native x86 (selectAny laço) + Script; riscv/aarch por
-   construção (mesmo IR), prova com assert-only (padrão bug 59).
+2. **S2:** Native x86 (selectAny laço) + Script. ⚠️ **Emenda 11/09:**
+   riscv/aarch **não** saem por construção — `selectAny` não existe lá
+   (DD-OTP-03/09). Ou entram com fallback de uma thread supervisora por
+   filho, ou ficam PARTIAL com um worker por supervisor.
 3. **S3:** `supervisorStats` + janela ring + `temporary` drop + docs de
    paridade; promote p/ stable só com a matriz de gates completa (R5).
 


### PR DESCRIPTION
refs #83 — **não fecha**. O documento está `PROPOSED` e a decisão é da mantenedora (regra 6). Este PR não decide: verifica as premissas e redige o fechamento do que já é consensual, para que a ratificação seja uma leitura.

## Duas emendas materiais

**1. `selectAny` não existe em riscv64/aarch64.**
`nat/NativeRiscvSpawn.java` emite apenas `kof_spawn_result`, `kof_spawn`, `kof_await`, `kof_spawn_join_all`. Como o **DD-OTP-03** elege `selectAny` como mecanismo para N workers, o *"riscv/aarch de graça"* do **DD-OTP-09** não se sustenta — seria literalmente *"uma API real num backend e promessa nos outros"*, o que a própria proposta diz não fazer sentido.

Agravante: não há gate de compile-time (`NativeRiscvCrossOps.resolveCalleeNameRiscv:305` cai no `sanitizeName` e emite a `call`), então o erro aparece só no link. Registrado como #91.

Cobertura real: **JVM + Native x86_64 + JS + Script**; riscv/aarch como PARTIAL declarada.

**2. DD-OTP-08 — BLOQUEADA.**
A flag `Bool` em `Box` não tem garantia de visibilidade. Depende da regra 5 do SG-020, que não está provada — `staticsAreSequentiallyConsistent:699` declara `Resultado.r1..r4` e nunca os usa; o que prova é a borda do `await`. E `volatile` é non-goal, com `BoxClassFactory.java:25` criando campo `AccessFlags.PUBLIC` simples (`ACC_VOLATILE` inexistente no compilador). Na JVM o laço do worker pode **nunca observar o `.stop()`** — passa em teste curto, trava em worker de longa duração, que é o caso de uso. Detalhes em #90.

## Mais

- **Seção nova "Separação de responsabilidades (supervisor / runtime / worker)"** — é o ponto principal declarado na discussão da #83 e não estava no documento.
- **DD-OTP-01:** a analogia *"objeto como `kof.mq`/`scheduler`"* não se sustenta — ambos são Java no compilador com runtime por backend; não há stdlib em `.kf` além de `resources/dev/kof/android-host.kf`. Falta especificar o empacotamento; *"zero código de backend"* na S1 está subestimado.
- **DD-OTP-11:** são os **quatro** gates nomeados na discussão, não um.

## Fechamento das 8 DDs independentes

04, 05, 06, 07, 10, 11, 12, 13 — cada uma com a limitação aceita explicitada. Painel de estado novo: **8 fechadas · 2 fecháveis com emenda · 2 abertas · 1 bloqueada.**

O **DD-OTP-07** tinha contradição real: pedia callback *"obrigatório no `start()` se há limite"* e na linha seguinte descrevia um *"default sem `.escalate`"*. Fechado como opcional-com-default — nunca mata o processo, nunca silencia (R6).

Base é `beta-0.4.0` (o documento não existe na `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxqWgYXoeEPh8p2ZunR2Fr
