### PR TITLE
docs(spec): SG-020 — registrar que a regra 5 ainda não tem prova

### DIFF
--- a/docs/concurrency-memory-model.md
+++ b/docs/concurrency-memory-model.md
@@ -76,6 +76,33 @@ de HB da §2 com os E2Es da §4 antes de sair de `experimental`.
 > valor parcial) IMPLEMENTADOS** — `KofConcurrency2Test:699/:737`, verde na
 > suíte (29/0/1-skip qemu). Todas as 5 bordas de HB da §2 têm prova.
 
+> **⚠️ Emenda 11/09 — a regra 5 ainda não tem prova.** Revisão de
+> `KofConcurrency2Test:699` (`staticsAreSequentiallyConsistent`): o programa
+> declara `Resultado.r1..r4` e **nunca os usa** — as quatro tarefas chamam
+> `soma1000()`, função pura sem estado compartilhado, e o pai soma os valores
+> devolvidos pelos `await`. Não há **nenhuma escrita concorrente em campo
+> compartilhado** no teste. O que ele demonstra é a borda **2 (await)**, não a
+> regra **5 (SC para statics e campos de objetos)**. O comentário do próprio
+> teste já reconhece o limite: *"data race de read-modify-write NÃO é atômico
+> por definição do modelo"*.
+>
+> `noWordTearingOnLong` (`:737`) **é** prova real da regra 6 — há escrita
+> concorrente em `Estado.v` com leitura em laço.
+>
+> **Lacuna que importa para `development/planning-otp-supervision.md`
+> (DD-OTP-08):** o padrão **stop-flag** — um fluxo escreve `Bool = true`, outro
+> lê em laço até observar — não é coberto por teste nenhum. `Estado.pronto` é
+> escrito em `noWordTearingOnLong` e nunca lido. Como `volatile` é non-goal
+> (§5) e `BoxClassFactory.java:25` cria o campo como `AccessFlags.PUBLIC`
+> simples (`ACC_VOLATILE` não aparece em nenhum ponto do compilador), na JVM a
+> visibilidade da flag depende inteiramente de a regra 5 valer — justamente a
+> que falta provar. Sem isso, `.stop()` pode nunca ser observado por um worker
+> de longa duração: falha que **passa** em teste curto e **trava** em produção.
+>
+> **Pendência (destrava o DD-OTP-08):** ou um E2E do padrão stop-flag
+> (escritor + leitor em laço, com deadline que falha se a escrita nunca for
+> observada), ou reescrever a regra 5 para o que as provas de fato cobrem.
+
 ## 5. O que NÃO é especificado (non-goals)
 
 - `volatile`/`synchronized` explícitos na superfície da linguagem — Kof não


### PR DESCRIPTION
Closes #90

O SG-020 afirma que **as 5 bordas de HB da §2 têm prova**. A regra 5 — *"statics e campos de objetos compartilhados seguem SC"* — não tem.

## O que o teste citado realmente prova

`KofConcurrency2Test.staticsAreSequentiallyConsistent:699` declara `Resultado.r1..r4` e **nunca os usa**. As quatro tarefas chamam `soma1000()`, função pura, e o pai soma os valores devolvidos pelos `await`. **Não há escrita concorrente em campo compartilhado nenhuma** — o que ele demonstra é a borda **2 (await)**.

O comentário do próprio teste reconhece: *"data race de read-modify-write NÃO é atômico por definição do modelo"*.

`noWordTearingOnLong:737` **é** prova real da regra 6 — há escrita concorrente em `Estado.v` com leitura em laço.

## A lacuna que importa

O padrão **stop-flag** — escrever `Bool = true` num fluxo e ler em laço noutro — não é coberto por teste nenhum. `Estado.pronto` é escrito em `noWordTearingOnLong` e nunca lido. E não há rede: `volatile` é non-goal (§5), `BoxClassFactory.java:25` cria campo `AccessFlags.PUBLIC` simples, `ACC_VOLATILE` não aparece em ponto nenhum do compilador.

Bloqueia o **DD-OTP-08** de `planning-otp-supervision.md` (#83), cujo `.stop()` é exatamente isso.

## Este PR

Só documenta a lacuna, com a pendência declarada: ou um E2E do padrão stop-flag (escritor + leitor em laço, com deadline que falha se a escrita nunca for observada), ou reescrever a regra 5 para o que as provas cobrem. Zero código, zero mudança de spec — a decisão é da mantenedora.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxqWgYXoeEPh8p2ZunR2Fr
